### PR TITLE
Add option to not downsample images in PylonDriver

### DIFF
--- a/include/trifinger_cameras/pylon_driver.hpp
+++ b/include/trifinger_cameras/pylon_driver.hpp
@@ -30,12 +30,13 @@ namespace trifinger_cameras
 class PylonDriver : public robot_interfaces::SensorDriver<CameraObservation>
 {
 public:
-
     /**
-     * @param device_user_id_to_open The id of the camera device to open and
-     * grab images from
+     * @param device_user_id "DeviceUserID" of the camera.
+     * @param downsample_images If set to true (default), images are downsampled
+     *     to half their original size.
      */
-    PylonDriver(const std::string& device_user_id_to_open);
+    PylonDriver(const std::string& device_user_id,
+                bool downsample_images = true);
 
     ~PylonDriver();
 
@@ -47,6 +48,7 @@ public:
     CameraObservation get_observation();
 
 private:
+    const bool downsample_images_;
     Pylon::PylonAutoInitTerm auto_init_term_;
     Pylon::CInstantCamera camera_;
 

--- a/include/trifinger_cameras/tricamera_driver.hpp
+++ b/include/trifinger_cameras/tricamera_driver.hpp
@@ -31,10 +31,13 @@ public:
      * @param device_id_1 device user id of first camera
      * @param device_id_2 likewise, the 2nd's
      * @param device_id_3 and the 3rd's
+     * @param downsample_images If set to true (default), images are
+     *     downsampled to half their original size.
      */
     TriCameraDriver(const std::string& device_id_1,
                     const std::string& device_id_2,
-                    const std::string& device_id_3);
+                    const std::string& device_id_3,
+                    bool downsample_images = true);
 
     /**
      * @brief Get the latest observation from the three cameras

--- a/scripts/record_image_dataset.py
+++ b/scripts/record_image_dataset.py
@@ -99,6 +99,11 @@ def main():
             For the "tri" driver, this value is ignored.
         """,
     )
+    argparser.add_argument(
+        "--no-downsample",
+        action="store_true",
+        help="""Do not downsample images.  Only for Pylon cameras.""",
+    )
     args = argparser.parse_args()
 
     if args.driver != "tri" and args.camera_id is None:
@@ -108,12 +113,14 @@ def main():
     if args.driver == "tri":
         camera_names = ["camera60", "camera180", "camera300"]
         camera_driver = trifinger_cameras.tricamera.TriCameraDriver(
-            *camera_names
+            *camera_names, not args.no_downsample
         )
         camera_module = trifinger_cameras.tricamera
         image_saver = TriImageSaver(args.outdir, camera_names)
     elif args.driver == "pylon":
-        camera_driver = trifinger_cameras.camera.PylonDriver(args.camera_id)
+        camera_driver = trifinger_cameras.camera.PylonDriver(
+            args.camera_id, not args.no_downsample
+        )
         camera_module = trifinger_cameras.camera
         image_saver = SingleImageSaver(args.outdir, args.camera_id)
     elif args.driver == "opencv":

--- a/src/tricamera_driver.cpp
+++ b/src/tricamera_driver.cpp
@@ -16,11 +16,12 @@ constexpr std::chrono::milliseconds TriCameraDriver::rate;
 
 TriCameraDriver::TriCameraDriver(const std::string& device_id_1,
                                  const std::string& device_id_2,
-                                 const std::string& device_id_3)
+                                 const std::string& device_id_3,
+                                 bool downsample_images)
     : last_update_time_(std::chrono::system_clock::now()),
-      camera1_(device_id_1),
-      camera2_(device_id_2),
-      camera3_(device_id_3)
+      camera1_(device_id_1, downsample_images),
+      camera2_(device_id_2, downsample_images),
+      camera3_(device_id_3, downsample_images)
 {
 }
 

--- a/srcpy/py_camera_types.cpp
+++ b/srcpy/py_camera_types.cpp
@@ -32,7 +32,9 @@ PYBIND11_MODULE(py_camera_types, m)
     pybind11::class_<PylonDriver,
                      std::shared_ptr<PylonDriver>,
                      SensorDriver<CameraObservation>>(m, "PylonDriver")
-        .def(pybind11::init<const std::string&>())
+        .def(pybind11::init<const std::string&, bool>(),
+             pybind11::arg("device_user_id"),
+             pybind11::arg("downsample_images") = true)
         .def("get_observation", &PylonDriver::get_observation);
 #endif
 

--- a/srcpy/py_tricamera_types.cpp
+++ b/srcpy/py_tricamera_types.cpp
@@ -27,7 +27,12 @@ PYBIND11_MODULE(py_tricamera_types, m)
                      SensorDriver<TriCameraObservation>>(m, "TriCameraDriver")
         .def(pybind11::init<const std::string&,
                             const std::string&,
-                            const std::string&>())
+                            const std::string&,
+                            bool>(),
+             pybind11::arg("camera1"),
+             pybind11::arg("camera2"),
+             pybind11::arg("camera3"),
+             pybind11::arg("downsample_images") = true)
         .def("get_observation", &TriCameraDriver::get_observation);
 #endif
 


### PR DESCRIPTION
## Description

Add an option to the `PylonDriver` and `TriCameraDriver` to disable the downsampling of images.  Add a corresponding option to  record_image_dataset.py.

This is needed as we want to record full-sized images, e.g. for camera calibration.

Note that this will _not_ work with MultiProcessSensorData, as for the shared memory it is assumed that the messages all have the default size (i.e. as if initialized) but writing an image that is bigger than expected will violate this.  It is not an issue for the SingleProcessSensorData, though.


## How I Tested

By running record_image_dataset.py with and without downsampling.


## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
