### PR TITLE
Camera Config Parser for C++

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,8 @@ find_package(catkin REQUIRED
     pybind11_catkin
     robot_interfaces
     serialization_utils
+    sensor_msgs
+    yaml_cpp_catkin
 )
 
 find_package(OpenCV REQUIRED)
@@ -75,6 +77,12 @@ endif()
 add_library(pybullet_tricamera_driver src/pybullet_tricamera_driver.cpp)
 target_link_libraries(pybullet_tricamera_driver
     ${catkin_LIBRARIES} camera_observations)
+
+add_library(camera_calibration_parser src/parse_yml.cpp)
+target_link_libraries(camera_calibration_parser ${catkin_LIBRARIES})
+
+add_executable(load_camera_config_test src/load_camera_config_test.cpp)
+target_link_libraries(load_camera_config_test camera_calibration_parser)
 
 
 # Python Bindings

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,6 @@ find_package(catkin REQUIRED
     pybind11_catkin
     robot_interfaces
     serialization_utils
-    sensor_msgs
     yaml_cpp_catkin
 )
 
@@ -40,6 +39,7 @@ catkin_package(
         ${pylon_driver}
         ${tricamera_driver}
         pybullet_tricamera_driver
+        camera_calibration_parser
 )
 
 
@@ -78,7 +78,10 @@ add_library(pybullet_tricamera_driver src/pybullet_tricamera_driver.cpp)
 target_link_libraries(pybullet_tricamera_driver
     ${catkin_LIBRARIES} camera_observations)
 
-add_library(camera_calibration_parser src/parse_yml.cpp)
+add_library(camera_calibration_parser
+    src/parse_yml.cpp
+    src/camera_parameters.cpp
+)
 target_link_libraries(camera_calibration_parser ${catkin_LIBRARIES})
 
 add_executable(load_camera_config_test src/load_camera_config_test.cpp)

--- a/include/trifinger_cameras/camera_parameters.hpp
+++ b/include/trifinger_cameras/camera_parameters.hpp
@@ -1,0 +1,26 @@
+/**
+ * @file
+ * @copyright 2020 Max Planck Gesellschaft. All rights reserved.
+ * @license BSD 3-clause
+ */
+#pragma once
+
+#include <Eigen/Eigen>
+#include <ostream>
+
+namespace trifinger_cameras
+{
+struct CameraParameters
+{
+    unsigned int image_width;
+    unsigned int image_height;
+
+    Eigen::Matrix3d camera_matrix;
+    Eigen::Matrix<double, 5, 1> distortion_coefficients;
+
+    Eigen::Matrix4d tf_world_to_camera;
+};
+
+std::ostream& operator<<(std::ostream& os, const CameraParameters& cp);
+
+}  // namespace trifinger_cameras

--- a/include/trifinger_cameras/camera_parameters.hpp
+++ b/include/trifinger_cameras/camera_parameters.hpp
@@ -16,7 +16,7 @@ struct CameraParameters
     unsigned int image_height;
 
     Eigen::Matrix3d camera_matrix;
-    Eigen::Matrix<double, 5, 1> distortion_coefficients;
+    Eigen::Matrix<double, 1, 5> distortion_coefficients;
 
     Eigen::Matrix4d tf_world_to_camera;
 };

--- a/include/trifinger_cameras/parse_yml.h
+++ b/include/trifinger_cameras/parse_yml.h
@@ -1,0 +1,86 @@
+/*********************************************************************
+* Software License Agreement (BSD License)
+* 
+*  Copyright (c) 2009, Willow Garage, Inc.
+*  All rights reserved.
+* 
+*  Redistribution and use in source and binary forms, with or without
+*  modification, are permitted provided that the following conditions
+*  are met:
+* 
+*   * Redistributions of source code must retain the above copyright
+*     notice, this list of conditions and the following disclaimer.
+*   * Redistributions in binary form must reproduce the above
+*     copyright notice, this list of conditions and the following
+*     disclaimer in the documentation and/or other materials provided
+*     with the distribution.
+*   * Neither the name of the Willow Garage nor the names of its
+*     contributors may be used to endorse or promote products derived
+*     from this software without specific prior written permission.
+* 
+*  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+*  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+*  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+*  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+*  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+*  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+*  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+*  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+*  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+*  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+*  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+*  POSSIBILITY OF SUCH DAMAGE.
+*********************************************************************/
+
+#ifndef CAMERA_CALIBRATION_PARSERS_PARSE_YML_H
+#define CAMERA_CALIBRATION_PARSERS_PARSE_YML_H
+
+#include <string>
+#include <istream>
+#include <ostream>
+#include <sensor_msgs/CameraInfo.h>
+
+namespace camera_calibration_parsers {
+
+/**
+ * \brief Write calibration parameters to a file in YAML format.
+ *
+ * \param out Output stream to write to
+ * \param camera_name Name of the camera
+ * \param cam_info Camera parameters
+ */
+bool writeCalibrationYml(std::ostream& out, const std::string& camera_name,
+                         const sensor_msgs::CameraInfo& cam_info);
+
+/**
+ * \brief Read calibration parameters from a YAML file.
+ *
+ * \param in Input stream to read from
+ * \param[out] camera_name Name of the camera
+ * \param[out] cam_info Camera parameters
+ */
+bool readCalibrationYml(std::istream& in, std::string& camera_name, sensor_msgs::CameraInfo& cam_info);
+
+/**
+ * \brief Write calibration parameters to a file in YAML format.
+ *
+ * \param file_name File to write
+ * \param camera_name Name of the camera
+ * \param cam_info Camera parameters
+ */
+bool writeCalibrationYml(const std::string& file_name, const std::string& camera_name,
+                         const sensor_msgs::CameraInfo& cam_info);
+
+/**
+ * \brief Read calibration parameters from a YAML file.
+ *
+ * \param file_name File to read
+ * \param[out] camera_name Name of the camera
+ * \param[out] cam_info Camera parameters
+ */
+bool readCalibrationYml(const std::string& file_name, std::string& camera_name,
+                        sensor_msgs::CameraInfo& cam_info);
+
+} //namespace camera_calibration_parsers
+
+#endif

--- a/include/trifinger_cameras/parse_yml.h
+++ b/include/trifinger_cameras/parse_yml.h
@@ -1,47 +1,47 @@
 /*********************************************************************
-* Software License Agreement (BSD License)
-* 
-*  Copyright (c) 2009, Willow Garage, Inc.
-*  All rights reserved.
-* 
-*  Redistribution and use in source and binary forms, with or without
-*  modification, are permitted provided that the following conditions
-*  are met:
-* 
-*   * Redistributions of source code must retain the above copyright
-*     notice, this list of conditions and the following disclaimer.
-*   * Redistributions in binary form must reproduce the above
-*     copyright notice, this list of conditions and the following
-*     disclaimer in the documentation and/or other materials provided
-*     with the distribution.
-*   * Neither the name of the Willow Garage nor the names of its
-*     contributors may be used to endorse or promote products derived
-*     from this software without specific prior written permission.
-* 
-*  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-*  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-*  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
-*  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-*  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
-*  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
-*  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-*  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-*  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
-*  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
-*  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-*  POSSIBILITY OF SUCH DAMAGE.
-*********************************************************************/
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2009, Willow Garage, Inc.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the Willow Garage nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
 
 #ifndef CAMERA_CALIBRATION_PARSERS_PARSE_YML_H
 #define CAMERA_CALIBRATION_PARSERS_PARSE_YML_H
 
-#include <string>
+#include <sensor_msgs/CameraInfo.h>
 #include <istream>
 #include <ostream>
-#include <sensor_msgs/CameraInfo.h>
+#include <string>
 
-namespace camera_calibration_parsers {
-
+namespace camera_calibration_parsers
+{
 /**
  * \brief Write calibration parameters to a file in YAML format.
  *
@@ -49,7 +49,8 @@ namespace camera_calibration_parsers {
  * \param camera_name Name of the camera
  * \param cam_info Camera parameters
  */
-bool writeCalibrationYml(std::ostream& out, const std::string& camera_name,
+bool writeCalibrationYml(std::ostream& out,
+                         const std::string& camera_name,
                          const sensor_msgs::CameraInfo& cam_info);
 
 /**
@@ -59,7 +60,9 @@ bool writeCalibrationYml(std::ostream& out, const std::string& camera_name,
  * \param[out] camera_name Name of the camera
  * \param[out] cam_info Camera parameters
  */
-bool readCalibrationYml(std::istream& in, std::string& camera_name, sensor_msgs::CameraInfo& cam_info);
+bool readCalibrationYml(std::istream& in,
+                        std::string& camera_name,
+                        sensor_msgs::CameraInfo& cam_info);
 
 /**
  * \brief Write calibration parameters to a file in YAML format.
@@ -68,7 +71,8 @@ bool readCalibrationYml(std::istream& in, std::string& camera_name, sensor_msgs:
  * \param camera_name Name of the camera
  * \param cam_info Camera parameters
  */
-bool writeCalibrationYml(const std::string& file_name, const std::string& camera_name,
+bool writeCalibrationYml(const std::string& file_name,
+                         const std::string& camera_name,
                          const sensor_msgs::CameraInfo& cam_info);
 
 /**
@@ -78,9 +82,10 @@ bool writeCalibrationYml(const std::string& file_name, const std::string& camera
  * \param[out] camera_name Name of the camera
  * \param[out] cam_info Camera parameters
  */
-bool readCalibrationYml(const std::string& file_name, std::string& camera_name,
+bool readCalibrationYml(const std::string& file_name,
+                        std::string& camera_name,
                         sensor_msgs::CameraInfo& cam_info);
 
-} //namespace camera_calibration_parsers
+}  // namespace camera_calibration_parsers
 
 #endif

--- a/include/trifinger_cameras/parse_yml.h
+++ b/include/trifinger_cameras/parse_yml.h
@@ -33,10 +33,10 @@
  *********************************************************************/
 #pragma once
 
-#include <sensor_msgs/CameraInfo.h>
 #include <istream>
-#include <ostream>
 #include <string>
+
+#include <trifinger_cameras/camera_parameters.hpp>
 
 namespace trifinger_cameras
 {
@@ -49,7 +49,7 @@ namespace trifinger_cameras
  */
 bool readCalibrationYml(std::istream& in,
                         std::string& camera_name,
-                        sensor_msgs::CameraInfo& cam_info);
+                        CameraParameters& cam_info);
 
 /**
  * \brief Read calibration parameters from a YAML file.
@@ -60,6 +60,6 @@ bool readCalibrationYml(std::istream& in,
  */
 bool readCalibrationYml(const std::string& file_name,
                         std::string& camera_name,
-                        sensor_msgs::CameraInfo& cam_info);
+                        CameraParameters& cam_info);
 
-}  // namespace camera_calibration_parsers
+}  // namespace trifinger_cameras

--- a/include/trifinger_cameras/parse_yml.h
+++ b/include/trifinger_cameras/parse_yml.h
@@ -31,28 +31,15 @@
  *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *  POSSIBILITY OF SUCH DAMAGE.
  *********************************************************************/
-
-#ifndef CAMERA_CALIBRATION_PARSERS_PARSE_YML_H
-#define CAMERA_CALIBRATION_PARSERS_PARSE_YML_H
+#pragma once
 
 #include <sensor_msgs/CameraInfo.h>
 #include <istream>
 #include <ostream>
 #include <string>
 
-namespace camera_calibration_parsers
+namespace trifinger_cameras
 {
-/**
- * \brief Write calibration parameters to a file in YAML format.
- *
- * \param out Output stream to write to
- * \param camera_name Name of the camera
- * \param cam_info Camera parameters
- */
-bool writeCalibrationYml(std::ostream& out,
-                         const std::string& camera_name,
-                         const sensor_msgs::CameraInfo& cam_info);
-
 /**
  * \brief Read calibration parameters from a YAML file.
  *
@@ -63,17 +50,6 @@ bool writeCalibrationYml(std::ostream& out,
 bool readCalibrationYml(std::istream& in,
                         std::string& camera_name,
                         sensor_msgs::CameraInfo& cam_info);
-
-/**
- * \brief Write calibration parameters to a file in YAML format.
- *
- * \param file_name File to write
- * \param camera_name Name of the camera
- * \param cam_info Camera parameters
- */
-bool writeCalibrationYml(const std::string& file_name,
-                         const std::string& camera_name,
-                         const sensor_msgs::CameraInfo& cam_info);
 
 /**
  * \brief Read calibration parameters from a YAML file.
@@ -87,5 +63,3 @@ bool readCalibrationYml(const std::string& file_name,
                         sensor_msgs::CameraInfo& cam_info);
 
 }  // namespace camera_calibration_parsers
-
-#endif

--- a/package.xml
+++ b/package.xml
@@ -17,10 +17,11 @@
     <depend>pybind11_catkin</depend>
     <depend>robot_interfaces</depend>
     <depend>serialization_utils</depend>
+    <depend>sensor_msgs</depend>
+    <depend>yaml_cpp_catkin</depend>
 
     <exec_depend>rospy</exec_depend>
     <exec_depend>geometry_msgs</exec_depend>
-    <exec_depend>sensor_msgs</exec_depend>
     <exec_depend>cv_bridge</exec_depend>
     <exec_depend>tf</exec_depend>
 

--- a/package.xml
+++ b/package.xml
@@ -17,11 +17,11 @@
     <depend>pybind11_catkin</depend>
     <depend>robot_interfaces</depend>
     <depend>serialization_utils</depend>
-    <depend>sensor_msgs</depend>
     <depend>yaml_cpp_catkin</depend>
 
     <exec_depend>rospy</exec_depend>
     <exec_depend>geometry_msgs</exec_depend>
+    <exec_depend>sensor_msgs</exec_depend>
     <exec_depend>cv_bridge</exec_depend>
     <exec_depend>tf</exec_depend>
 

--- a/src/camera_parameters.cpp
+++ b/src/camera_parameters.cpp
@@ -1,0 +1,23 @@
+/**
+ * @file
+ * @copyright 2020 Max Planck Gesellschaft. All rights reserved.
+ * @license BSD 3-clause
+ */
+#include <trifinger_cameras/camera_parameters.hpp>
+
+namespace trifinger_cameras
+{
+std::ostream& operator<<(std::ostream& os, const CameraParameters& cp)
+{
+    os << "CameraParameters:" << std::endl
+       << "image_width: " << cp.image_width << std::endl
+       << "image_height: " << cp.image_height << std::endl
+       << "distortion_coefficients: " << cp.distortion_coefficients.transpose()
+       << std::endl
+       << "camera_matrix:" << std::endl
+       << cp.camera_matrix << std::endl
+       << "tf_world_to_camera:" << std::endl
+       << cp.tf_world_to_camera << std::endl;
+    return os;
+}
+}  // namespace trifinger_cameras

--- a/src/camera_parameters.cpp
+++ b/src/camera_parameters.cpp
@@ -12,7 +12,7 @@ std::ostream& operator<<(std::ostream& os, const CameraParameters& cp)
     os << "CameraParameters:" << std::endl
        << "image_width: " << cp.image_width << std::endl
        << "image_height: " << cp.image_height << std::endl
-       << "distortion_coefficients: " << cp.distortion_coefficients.transpose()
+       << "distortion_coefficients: " << cp.distortion_coefficients
        << std::endl
        << "camera_matrix:" << std::endl
        << cp.camera_matrix << std::endl

--- a/src/load_camera_config_test.cpp
+++ b/src/load_camera_config_test.cpp
@@ -1,0 +1,22 @@
+#include <trifinger_cameras/parse_yml.h>
+#include <sensor_msgs/CameraInfo.h>
+
+
+int main(int argc, char* argv[])
+{
+    std::string file = argv[1];
+    std::string camera_name;
+    sensor_msgs::CameraInfo cam_info;
+
+    bool suc = trifinger_cameras::readCalibrationYml(file, camera_name, cam_info);
+
+    if (suc)
+    {
+        std::cout << "camera name: " << camera_name << std::endl;
+        std::cout << cam_info << std::endl;
+    }
+    else
+    {
+        std::cout << "Failure" << std::endl;
+    }
+}

--- a/src/load_camera_config_test.cpp
+++ b/src/load_camera_config_test.cpp
@@ -7,13 +7,14 @@ int main(int argc, char* argv[])
     std::string file = argv[1];
     std::string camera_name;
     sensor_msgs::CameraInfo cam_info;
+    trifinger_cameras::CameraParameters params;
 
-    bool suc = trifinger_cameras::readCalibrationYml(file, camera_name, cam_info);
+    bool suc = trifinger_cameras::readCalibrationYml(file, camera_name, params);
 
     if (suc)
     {
         std::cout << "camera name: " << camera_name << std::endl;
-        std::cout << cam_info << std::endl;
+        std::cout << params << std::endl;
     }
     else
     {

--- a/src/parse_yml.cpp
+++ b/src/parse_yml.cpp
@@ -1,0 +1,240 @@
+/*********************************************************************
+* Software License Agreement (BSD License)
+* 
+*  Copyright (c) 2009, Willow Garage, Inc.
+*  All rights reserved.
+* 
+*  Redistribution and use in source and binary forms, with or without
+*  modification, are permitted provided that the following conditions
+*  are met:
+* 
+*   * Redistributions of source code must retain the above copyright
+*     notice, this list of conditions and the following disclaimer.
+*   * Redistributions in binary form must reproduce the above
+*     copyright notice, this list of conditions and the following
+*     disclaimer in the documentation and/or other materials provided
+*     with the distribution.
+*   * Neither the name of the Willow Garage nor the names of its
+*     contributors may be used to endorse or promote products derived
+*     from this software without specific prior written permission.
+* 
+*  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+*  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+*  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+*  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+*  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+*  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+*  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+*  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+*  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+*  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+*  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+*  POSSIBILITY OF SUCH DAMAGE.
+*********************************************************************/
+
+#include "camera_calibration_parsers/parse_yml.h"
+#include <sensor_msgs/distortion_models.h>
+#include <boost/filesystem.hpp>
+#include <yaml-cpp/yaml.h>
+#include <fstream>
+#include <ctime>
+#include <cassert>
+#include <cstring>
+#include <ros/console.h>
+
+namespace camera_calibration_parsers {
+
+/// \cond
+
+static const char CAM_YML_NAME[]    = "camera_name";
+static const char WIDTH_YML_NAME[]  = "image_width";
+static const char HEIGHT_YML_NAME[] = "image_height";
+static const char K_YML_NAME[]      = "camera_matrix";
+static const char D_YML_NAME[]      = "distortion_coefficients";
+static const char R_YML_NAME[]      = "rectification_matrix";
+static const char P_YML_NAME[]      = "projection_matrix";
+static const char DMODEL_YML_NAME[] = "distortion_model";
+
+struct SimpleMatrix
+{
+  int rows;
+  int cols;
+  double* data;
+
+  SimpleMatrix(int rows, int cols, double* data)
+    : rows(rows), cols(cols), data(data)
+  {}
+};
+
+YAML::Emitter& operator << (YAML::Emitter& out, const SimpleMatrix& m)
+{
+  out << YAML::BeginMap;
+  out << YAML::Key << "rows" << YAML::Value << m.rows;
+  out << YAML::Key << "cols" << YAML::Value << m.cols;
+  //out << YAML::Key << "dt"   << YAML::Value << "d"; // OpenCV data type specifier
+  out << YAML::Key << "data" << YAML::Value;
+  out << YAML::Flow;
+  out << YAML::BeginSeq;
+  for (int i = 0; i < m.rows*m.cols; ++i)
+    out << m.data[i];
+  out << YAML::EndSeq;
+  out << YAML::EndMap;
+  return out;
+}
+
+#ifdef HAVE_NEW_YAMLCPP
+template<typename T>
+void operator >> (const YAML::Node& node, T& i)
+{
+  i = node.as<T>();
+}
+#endif
+
+void operator >> (const YAML::Node& node, SimpleMatrix& m)
+{
+  int rows, cols;
+  node["rows"] >> rows;
+  assert(rows == m.rows);
+  node["cols"] >> cols;
+  assert(cols == m.cols);
+  const YAML::Node& data = node["data"];
+  for (int i = 0; i < rows*cols; ++i)
+    data[i] >> m.data[i];
+}
+
+/// \endcond
+
+bool writeCalibrationYml(std::ostream& out, const std::string& camera_name,
+                         const sensor_msgs::CameraInfo& cam_info)
+{
+  YAML::Emitter emitter;
+  emitter << YAML::BeginMap;
+
+#if 0
+  // Calibration time
+  /// @todo Emitting the time breaks yaml-cpp on reading for some reason
+  time_t raw_time;
+  time( &raw_time );
+  emitter << YAML::Key << "calibration_time";
+  emitter << YAML::Value << asctime(localtime(&raw_time));
+#endif
+
+  // Image dimensions
+  emitter << YAML::Key << WIDTH_YML_NAME << YAML::Value << (int)cam_info.width;
+  emitter << YAML::Key << HEIGHT_YML_NAME << YAML::Value << (int)cam_info.height;
+  
+  // Camera name and intrinsics
+  emitter << YAML::Key << CAM_YML_NAME << YAML::Value << camera_name;
+  emitter << YAML::Key << K_YML_NAME << YAML::Value << SimpleMatrix(3, 3, const_cast<double*>(&cam_info.K[0]));
+  emitter << YAML::Key << DMODEL_YML_NAME << YAML::Value << cam_info.distortion_model;
+  emitter << YAML::Key << D_YML_NAME << YAML::Value << SimpleMatrix(1, cam_info.D.size(),
+                                                                    const_cast<double*>(&cam_info.D[0]));
+  emitter << YAML::Key << R_YML_NAME << YAML::Value << SimpleMatrix(3, 3, const_cast<double*>(&cam_info.R[0]));
+  emitter << YAML::Key << P_YML_NAME << YAML::Value << SimpleMatrix(3, 4, const_cast<double*>(&cam_info.P[0]));
+
+  emitter << YAML::EndMap;
+
+  out << emitter.c_str();
+  return true;
+}
+
+bool writeCalibrationYml(const std::string& file_name, const std::string& camera_name,
+                         const sensor_msgs::CameraInfo& cam_info)
+{
+  boost::filesystem::path dir(boost::filesystem::path(file_name).parent_path());
+  if (!dir.empty() && !boost::filesystem::exists(dir) &&
+     !boost::filesystem::create_directories(dir)){
+    ROS_ERROR("Unable to create directory for camera calibration file [%s]", dir.c_str());
+  }
+  std::ofstream out(file_name.c_str());
+  if (!out.is_open())
+  {
+    ROS_ERROR("Unable to open camera calibration file [%s] for writing", file_name.c_str());
+    return false;
+  }
+  return writeCalibrationYml(out, camera_name, cam_info);
+}
+
+bool readCalibrationYml(std::istream& in, std::string& camera_name, sensor_msgs::CameraInfo& cam_info)
+{
+  try {
+#ifdef HAVE_NEW_YAMLCPP
+    YAML::Node doc = YAML::Load(in);
+
+    if (doc[CAM_YML_NAME])
+      doc[CAM_YML_NAME] >> camera_name;
+    else
+      camera_name = "unknown";
+#else
+    YAML::Parser parser(in);
+    if (!parser) {
+      ROS_ERROR("Unable to create YAML parser for camera calibration");
+      return false;
+    }
+    YAML::Node doc;
+    parser.GetNextDocument(doc);
+
+    if (const YAML::Node* name_node = doc.FindValue(CAM_YML_NAME))
+      *name_node >> camera_name;
+    else
+      camera_name = "unknown";
+#endif
+
+    doc[WIDTH_YML_NAME] >> cam_info.width;
+    doc[HEIGHT_YML_NAME] >> cam_info.height;
+
+    // Read in fixed-size matrices
+    SimpleMatrix K_(3, 3, &cam_info.K[0]);
+    doc[K_YML_NAME] >> K_;
+    SimpleMatrix R_(3, 3, &cam_info.R[0]);
+    doc[R_YML_NAME] >> R_;
+    SimpleMatrix P_(3, 4, &cam_info.P[0]);
+    doc[P_YML_NAME] >> P_;
+
+    // Different distortion models may have different numbers of parameters
+#ifdef HAVE_NEW_YAMLCPP
+    if (doc[DMODEL_YML_NAME]) {
+      doc[DMODEL_YML_NAME] >> cam_info.distortion_model;
+    }
+#else
+    if (const YAML::Node* model_node = doc.FindValue(DMODEL_YML_NAME)) {
+      *model_node >> cam_info.distortion_model;
+    }
+#endif
+    else {
+      // Assume plumb bob for backwards compatibility
+      cam_info.distortion_model = sensor_msgs::distortion_models::PLUMB_BOB;
+      ROS_WARN("Camera calibration file did not specify distortion model, assuming plumb bob");
+    }
+    const YAML::Node& D_node = doc[D_YML_NAME];
+    int D_rows, D_cols;
+    D_node["rows"] >> D_rows;
+    D_node["cols"] >> D_cols;
+    const YAML::Node& D_data = D_node["data"];
+    cam_info.D.resize(D_rows*D_cols);
+    for (int i = 0; i < D_rows*D_cols; ++i)
+      D_data[i] >> cam_info.D[i];
+  
+    return true;
+  }
+  catch (YAML::Exception& e) {
+    ROS_ERROR("Exception parsing YAML camera calibration:\n%s", e.what());
+    return false;
+  }
+}
+
+bool readCalibrationYml(const std::string& file_name, std::string& camera_name,
+                        sensor_msgs::CameraInfo& cam_info)
+{
+  std::ifstream fin(file_name.c_str());
+  if (!fin.good()) {
+    ROS_INFO("Unable to open camera calibration file [%s]", file_name.c_str());
+    return false;
+  }
+  bool success = readCalibrationYml(fin, camera_name, cam_info);
+  if (!success)
+    ROS_ERROR("Failed to parse camera calibration from file [%s]", file_name.c_str());
+  return success;
+}
+
+} //namespace camera_calibration_parsers

--- a/src/parse_yml.cpp
+++ b/src/parse_yml.cpp
@@ -34,7 +34,6 @@
 
 #include <trifinger_cameras/parse_yml.h>
 
-#include <Eigen/Eigen>
 #include <sensor_msgs/distortion_models.h>
 #include <yaml-cpp/yaml.h>
 #include <boost/filesystem.hpp>
@@ -42,22 +41,10 @@
 #include <cstring>
 #include <ctime>
 #include <fstream>
+#include <iostream>
 
 namespace trifinger_cameras
 {
-
-struct CameraParameters
-{
-    unsigned int image_width;
-    unsigned int image_height;
-
-    Eigen::Matrix3d camera_matrix;
-    Eigen::Matrix<double, 5, 1> distortion_coefficients;
-
-    Eigen::Matrix4d tf_world_to_camera;
-};
-
-
 static const char CAM_YML_NAME[] = "camera_name";
 static const char WIDTH_YML_NAME[] = "image_width";
 static const char HEIGHT_YML_NAME[] = "image_height";
@@ -67,45 +54,22 @@ static const char R_YML_NAME[] = "rectification_matrix";
 static const char P_YML_NAME[] = "projection_matrix";
 static const char DMODEL_YML_NAME[] = "distortion_model";
 
-struct SimpleMatrix
-{
-    int rows;
-    int cols;
-    double* data;
-
-    SimpleMatrix(int rows, int cols, double* data)
-        : rows(rows), cols(cols), data(data)
-    {
-    }
-};
-
 template <typename T>
 void operator>>(const YAML::Node& node, T& i)
 {
     i = node.as<T>();
 }
 
-void operator>>(const YAML::Node& node, SimpleMatrix& m)
+template <typename T>
+void yaml_to_eigen(const YAML::Node& node, T& m)
 {
     int rows, cols;
-    rows = node["rows"].as<int>();
-    assert(rows == m.rows);
-    cols = node["cols"].as<int>();
-    assert(cols == m.cols);
-    const YAML::Node& data = node["data"];
-    for (int i = 0; i < rows * cols; ++i)
-    {
-        m.data[i] = data[i].as<double>();
-    }
-}
 
-void operator>>(const YAML::Node& node, Eigen::Matrix3d& m)
-{
-    int rows, cols;
     rows = node["rows"].as<int>();
     assert(rows == m.rows());
     cols = node["cols"].as<int>();
     assert(cols == m.cols());
+
     const YAML::Node& data = node["data"];
     for (int i = 0; i < rows * cols; ++i)
     {
@@ -115,11 +79,27 @@ void operator>>(const YAML::Node& node, Eigen::Matrix3d& m)
     }
 }
 
+void operator>>(const YAML::Node& node, Eigen::Matrix3d& m)
+{
+    yaml_to_eigen(node, m);
+}
+
+void operator>>(const YAML::Node& node, Eigen::Matrix4d& m)
+{
+    yaml_to_eigen(node, m);
+}
+
+void operator>>(const YAML::Node& node, Eigen::Matrix<double, 5, 1>& m)
+{
+    yaml_to_eigen(node, m);
+}
+
+
 /// \endcond
 
 bool readCalibrationYml(std::istream& in,
                         std::string& camera_name,
-                        sensor_msgs::CameraInfo& cam_info)
+                        CameraParameters& cam_info)
 {
     std::string current_key = "none";
     try
@@ -133,49 +113,29 @@ bool readCalibrationYml(std::istream& in,
             camera_name = "unknown";
 
         current_key = WIDTH_YML_NAME;
-        doc[WIDTH_YML_NAME] >> cam_info.width;
+        doc[WIDTH_YML_NAME] >> cam_info.image_width;
         current_key = HEIGHT_YML_NAME;
-        doc[HEIGHT_YML_NAME] >> cam_info.height;
+        doc[HEIGHT_YML_NAME] >> cam_info.image_height;
 
         // Read in fixed-size matrices
-        SimpleMatrix K_(3, 3, &cam_info.K[0]);
         current_key = K_YML_NAME;
-        doc[K_YML_NAME] >> K_;
+        doc[K_YML_NAME] >> cam_info.camera_matrix;
+
+        current_key = D_YML_NAME;
+        doc[D_YML_NAME] >> cam_info.distortion_coefficients;
+
+        current_key = "tf_world_to_camera";
+        doc["tf_world_to_camera"] >> cam_info.tf_world_to_camera;
 
         // TODO: Disable rectification_matrix for now
-        //SimpleMatrix R_(3, 3, &cam_info.R[0]);
-        //current_key = R_YML_NAME;
-        //doc[R_YML_NAME] >> R_;
+        // SimpleMatrix R_(3, 3, &cam_info.R[0]);
+        // current_key = R_YML_NAME;
+        // doc[R_YML_NAME] >> R_;
 
         // TODO: Disable projection_matrix for now
-        //SimpleMatrix P_(3, 4, &cam_info.P[0]);
-        //current_key = P_YML_NAME;
-        //doc[P_YML_NAME] >> P_;
-
-        // Different distortion models may have different numbers of parameters
-        current_key = DMODEL_YML_NAME;
-        if (doc[DMODEL_YML_NAME])
-        {
-            doc[DMODEL_YML_NAME] >> cam_info.distortion_model;
-        }
-        else
-        {
-            // Assume plumb bob for backwards compatibility
-            cam_info.distortion_model =
-                sensor_msgs::distortion_models::PLUMB_BOB;
-            std::cout << "WARNING: Camera calibration file did not specify "
-                         "distortion model, "
-                         "assuming plumb bob"
-                      << std::endl;
-        }
-        current_key = D_YML_NAME;
-        const YAML::Node& D_node = doc[D_YML_NAME];
-        int D_rows, D_cols;
-        D_node["rows"] >> D_rows;
-        D_node["cols"] >> D_cols;
-        const YAML::Node& D_data = D_node["data"];
-        cam_info.D.resize(D_rows * D_cols);
-        for (int i = 0; i < D_rows * D_cols; ++i) D_data[i] >> cam_info.D[i];
+        // SimpleMatrix P_(3, 4, &cam_info.P[0]);
+        // current_key = P_YML_NAME;
+        // doc[P_YML_NAME] >> P_;
 
         return true;
     }
@@ -190,7 +150,7 @@ bool readCalibrationYml(std::istream& in,
 
 bool readCalibrationYml(const std::string& file_name,
                         std::string& camera_name,
-                        sensor_msgs::CameraInfo& cam_info)
+                        CameraParameters& cam_info)
 {
     std::ifstream fin(file_name.c_str());
     if (!fin.good())

--- a/src/parse_yml.cpp
+++ b/src/parse_yml.cpp
@@ -67,15 +67,25 @@ void yaml_to_eigen(const YAML::Node& node, T& m)
     int rows, cols;
 
     rows = node["rows"].as<int>();
-    assert(rows == m.rows());
+    if (rows != m.rows())
+    {
+        throw std::runtime_error("Invalid number of rows. Expected " +
+                                 std::to_string(rows) + ", got " +
+                                 std::to_string(m.rows()));
+    }
     cols = node["cols"].as<int>();
-    assert(cols == m.cols());
+    if (cols != m.cols())
+    {
+        throw std::runtime_error("Invalid number of cols. Expected " +
+                                 std::to_string(cols) + ", got " +
+                                 std::to_string(m.cols()));
+    }
 
     const YAML::Node& data = node["data"];
     for (int i = 0; i < rows * cols; ++i)
     {
-        int r = i / rows;
-        int c = i - r * cols;
+        int r = i / cols;
+        int c = i % cols;
         m(r, c) = data[i].as<double>();
     }
 }
@@ -90,11 +100,10 @@ void operator>>(const YAML::Node& node, Eigen::Matrix4d& m)
     yaml_to_eigen(node, m);
 }
 
-void operator>>(const YAML::Node& node, Eigen::Matrix<double, 5, 1>& m)
+void operator>>(const YAML::Node& node, Eigen::Matrix<double, 1, 5>& m)
 {
     yaml_to_eigen(node, m);
 }
-
 
 /// \endcond
 
@@ -140,7 +149,7 @@ bool readCalibrationYml(std::istream& in,
 
         return true;
     }
-    catch (YAML::Exception& e)
+    catch (std::exception& e)
     {
         std::cerr << "Exception parsing YAML camera calibration:\n"
                   << e.what() << std::endl;

--- a/src/parse_yml.cpp
+++ b/src/parse_yml.cpp
@@ -2,6 +2,7 @@
  * Software License Agreement (BSD License)
  *
  *  Copyright (c) 2009, Willow Garage, Inc.
+ *  Copyright (c) 2020, Max Planck Gesellschaft
  *  All rights reserved.
  *
  *  Redistribution and use in source and binary forms, with or without

--- a/src/parse_yml.cpp
+++ b/src/parse_yml.cpp
@@ -1,114 +1,115 @@
 /*********************************************************************
-* Software License Agreement (BSD License)
-* 
-*  Copyright (c) 2009, Willow Garage, Inc.
-*  All rights reserved.
-* 
-*  Redistribution and use in source and binary forms, with or without
-*  modification, are permitted provided that the following conditions
-*  are met:
-* 
-*   * Redistributions of source code must retain the above copyright
-*     notice, this list of conditions and the following disclaimer.
-*   * Redistributions in binary form must reproduce the above
-*     copyright notice, this list of conditions and the following
-*     disclaimer in the documentation and/or other materials provided
-*     with the distribution.
-*   * Neither the name of the Willow Garage nor the names of its
-*     contributors may be used to endorse or promote products derived
-*     from this software without specific prior written permission.
-* 
-*  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-*  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-*  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
-*  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-*  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
-*  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
-*  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-*  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-*  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
-*  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
-*  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-*  POSSIBILITY OF SUCH DAMAGE.
-*********************************************************************/
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2009, Willow Garage, Inc.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the Willow Garage nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
 
 #include "camera_calibration_parsers/parse_yml.h"
+#include <ros/console.h>
 #include <sensor_msgs/distortion_models.h>
-#include <boost/filesystem.hpp>
 #include <yaml-cpp/yaml.h>
-#include <fstream>
-#include <ctime>
+#include <boost/filesystem.hpp>
 #include <cassert>
 #include <cstring>
-#include <ros/console.h>
+#include <ctime>
+#include <fstream>
 
-namespace camera_calibration_parsers {
-
+namespace camera_calibration_parsers
+{
 /// \cond
 
-static const char CAM_YML_NAME[]    = "camera_name";
-static const char WIDTH_YML_NAME[]  = "image_width";
+static const char CAM_YML_NAME[] = "camera_name";
+static const char WIDTH_YML_NAME[] = "image_width";
 static const char HEIGHT_YML_NAME[] = "image_height";
-static const char K_YML_NAME[]      = "camera_matrix";
-static const char D_YML_NAME[]      = "distortion_coefficients";
-static const char R_YML_NAME[]      = "rectification_matrix";
-static const char P_YML_NAME[]      = "projection_matrix";
+static const char K_YML_NAME[] = "camera_matrix";
+static const char D_YML_NAME[] = "distortion_coefficients";
+static const char R_YML_NAME[] = "rectification_matrix";
+static const char P_YML_NAME[] = "projection_matrix";
 static const char DMODEL_YML_NAME[] = "distortion_model";
 
 struct SimpleMatrix
 {
-  int rows;
-  int cols;
-  double* data;
+    int rows;
+    int cols;
+    double* data;
 
-  SimpleMatrix(int rows, int cols, double* data)
-    : rows(rows), cols(cols), data(data)
-  {}
+    SimpleMatrix(int rows, int cols, double* data)
+        : rows(rows), cols(cols), data(data)
+    {
+    }
 };
 
-YAML::Emitter& operator << (YAML::Emitter& out, const SimpleMatrix& m)
+YAML::Emitter& operator<<(YAML::Emitter& out, const SimpleMatrix& m)
 {
-  out << YAML::BeginMap;
-  out << YAML::Key << "rows" << YAML::Value << m.rows;
-  out << YAML::Key << "cols" << YAML::Value << m.cols;
-  //out << YAML::Key << "dt"   << YAML::Value << "d"; // OpenCV data type specifier
-  out << YAML::Key << "data" << YAML::Value;
-  out << YAML::Flow;
-  out << YAML::BeginSeq;
-  for (int i = 0; i < m.rows*m.cols; ++i)
-    out << m.data[i];
-  out << YAML::EndSeq;
-  out << YAML::EndMap;
-  return out;
+    out << YAML::BeginMap;
+    out << YAML::Key << "rows" << YAML::Value << m.rows;
+    out << YAML::Key << "cols" << YAML::Value << m.cols;
+    // out << YAML::Key << "dt"   << YAML::Value << "d"; // OpenCV data type
+    // specifier
+    out << YAML::Key << "data" << YAML::Value;
+    out << YAML::Flow;
+    out << YAML::BeginSeq;
+    for (int i = 0; i < m.rows * m.cols; ++i) out << m.data[i];
+    out << YAML::EndSeq;
+    out << YAML::EndMap;
+    return out;
 }
 
 #ifdef HAVE_NEW_YAMLCPP
-template<typename T>
-void operator >> (const YAML::Node& node, T& i)
+template <typename T>
+void operator>>(const YAML::Node& node, T& i)
 {
-  i = node.as<T>();
+    i = node.as<T>();
 }
 #endif
 
-void operator >> (const YAML::Node& node, SimpleMatrix& m)
+void operator>>(const YAML::Node& node, SimpleMatrix& m)
 {
-  int rows, cols;
-  node["rows"] >> rows;
-  assert(rows == m.rows);
-  node["cols"] >> cols;
-  assert(cols == m.cols);
-  const YAML::Node& data = node["data"];
-  for (int i = 0; i < rows*cols; ++i)
-    data[i] >> m.data[i];
+    int rows, cols;
+    node["rows"] >> rows;
+    assert(rows == m.rows);
+    node["cols"] >> cols;
+    assert(cols == m.cols);
+    const YAML::Node& data = node["data"];
+    for (int i = 0; i < rows * cols; ++i) data[i] >> m.data[i];
 }
 
 /// \endcond
 
-bool writeCalibrationYml(std::ostream& out, const std::string& camera_name,
+bool writeCalibrationYml(std::ostream& out,
+                         const std::string& camera_name,
                          const sensor_msgs::CameraInfo& cam_info)
 {
-  YAML::Emitter emitter;
-  emitter << YAML::BeginMap;
+    YAML::Emitter emitter;
+    emitter << YAML::BeginMap;
 
 #if 0
   // Calibration time
@@ -119,122 +120,148 @@ bool writeCalibrationYml(std::ostream& out, const std::string& camera_name,
   emitter << YAML::Value << asctime(localtime(&raw_time));
 #endif
 
-  // Image dimensions
-  emitter << YAML::Key << WIDTH_YML_NAME << YAML::Value << (int)cam_info.width;
-  emitter << YAML::Key << HEIGHT_YML_NAME << YAML::Value << (int)cam_info.height;
-  
-  // Camera name and intrinsics
-  emitter << YAML::Key << CAM_YML_NAME << YAML::Value << camera_name;
-  emitter << YAML::Key << K_YML_NAME << YAML::Value << SimpleMatrix(3, 3, const_cast<double*>(&cam_info.K[0]));
-  emitter << YAML::Key << DMODEL_YML_NAME << YAML::Value << cam_info.distortion_model;
-  emitter << YAML::Key << D_YML_NAME << YAML::Value << SimpleMatrix(1, cam_info.D.size(),
-                                                                    const_cast<double*>(&cam_info.D[0]));
-  emitter << YAML::Key << R_YML_NAME << YAML::Value << SimpleMatrix(3, 3, const_cast<double*>(&cam_info.R[0]));
-  emitter << YAML::Key << P_YML_NAME << YAML::Value << SimpleMatrix(3, 4, const_cast<double*>(&cam_info.P[0]));
+    // Image dimensions
+    emitter << YAML::Key << WIDTH_YML_NAME << YAML::Value
+            << (int)cam_info.width;
+    emitter << YAML::Key << HEIGHT_YML_NAME << YAML::Value
+            << (int)cam_info.height;
 
-  emitter << YAML::EndMap;
+    // Camera name and intrinsics
+    emitter << YAML::Key << CAM_YML_NAME << YAML::Value << camera_name;
+    emitter << YAML::Key << K_YML_NAME << YAML::Value
+            << SimpleMatrix(3, 3, const_cast<double*>(&cam_info.K[0]));
+    emitter << YAML::Key << DMODEL_YML_NAME << YAML::Value
+            << cam_info.distortion_model;
+    emitter << YAML::Key << D_YML_NAME << YAML::Value
+            << SimpleMatrix(
+                   1, cam_info.D.size(), const_cast<double*>(&cam_info.D[0]));
+    emitter << YAML::Key << R_YML_NAME << YAML::Value
+            << SimpleMatrix(3, 3, const_cast<double*>(&cam_info.R[0]));
+    emitter << YAML::Key << P_YML_NAME << YAML::Value
+            << SimpleMatrix(3, 4, const_cast<double*>(&cam_info.P[0]));
 
-  out << emitter.c_str();
-  return true;
+    emitter << YAML::EndMap;
+
+    out << emitter.c_str();
+    return true;
 }
 
-bool writeCalibrationYml(const std::string& file_name, const std::string& camera_name,
+bool writeCalibrationYml(const std::string& file_name,
+                         const std::string& camera_name,
                          const sensor_msgs::CameraInfo& cam_info)
 {
-  boost::filesystem::path dir(boost::filesystem::path(file_name).parent_path());
-  if (!dir.empty() && !boost::filesystem::exists(dir) &&
-     !boost::filesystem::create_directories(dir)){
-    ROS_ERROR("Unable to create directory for camera calibration file [%s]", dir.c_str());
-  }
-  std::ofstream out(file_name.c_str());
-  if (!out.is_open())
-  {
-    ROS_ERROR("Unable to open camera calibration file [%s] for writing", file_name.c_str());
-    return false;
-  }
-  return writeCalibrationYml(out, camera_name, cam_info);
+    boost::filesystem::path dir(
+        boost::filesystem::path(file_name).parent_path());
+    if (!dir.empty() && !boost::filesystem::exists(dir) &&
+        !boost::filesystem::create_directories(dir))
+    {
+        ROS_ERROR("Unable to create directory for camera calibration file [%s]",
+                  dir.c_str());
+    }
+    std::ofstream out(file_name.c_str());
+    if (!out.is_open())
+    {
+        ROS_ERROR("Unable to open camera calibration file [%s] for writing",
+                  file_name.c_str());
+        return false;
+    }
+    return writeCalibrationYml(out, camera_name, cam_info);
 }
 
-bool readCalibrationYml(std::istream& in, std::string& camera_name, sensor_msgs::CameraInfo& cam_info)
-{
-  try {
-#ifdef HAVE_NEW_YAMLCPP
-    YAML::Node doc = YAML::Load(in);
-
-    if (doc[CAM_YML_NAME])
-      doc[CAM_YML_NAME] >> camera_name;
-    else
-      camera_name = "unknown";
-#else
-    YAML::Parser parser(in);
-    if (!parser) {
-      ROS_ERROR("Unable to create YAML parser for camera calibration");
-      return false;
-    }
-    YAML::Node doc;
-    parser.GetNextDocument(doc);
-
-    if (const YAML::Node* name_node = doc.FindValue(CAM_YML_NAME))
-      *name_node >> camera_name;
-    else
-      camera_name = "unknown";
-#endif
-
-    doc[WIDTH_YML_NAME] >> cam_info.width;
-    doc[HEIGHT_YML_NAME] >> cam_info.height;
-
-    // Read in fixed-size matrices
-    SimpleMatrix K_(3, 3, &cam_info.K[0]);
-    doc[K_YML_NAME] >> K_;
-    SimpleMatrix R_(3, 3, &cam_info.R[0]);
-    doc[R_YML_NAME] >> R_;
-    SimpleMatrix P_(3, 4, &cam_info.P[0]);
-    doc[P_YML_NAME] >> P_;
-
-    // Different distortion models may have different numbers of parameters
-#ifdef HAVE_NEW_YAMLCPP
-    if (doc[DMODEL_YML_NAME]) {
-      doc[DMODEL_YML_NAME] >> cam_info.distortion_model;
-    }
-#else
-    if (const YAML::Node* model_node = doc.FindValue(DMODEL_YML_NAME)) {
-      *model_node >> cam_info.distortion_model;
-    }
-#endif
-    else {
-      // Assume plumb bob for backwards compatibility
-      cam_info.distortion_model = sensor_msgs::distortion_models::PLUMB_BOB;
-      ROS_WARN("Camera calibration file did not specify distortion model, assuming plumb bob");
-    }
-    const YAML::Node& D_node = doc[D_YML_NAME];
-    int D_rows, D_cols;
-    D_node["rows"] >> D_rows;
-    D_node["cols"] >> D_cols;
-    const YAML::Node& D_data = D_node["data"];
-    cam_info.D.resize(D_rows*D_cols);
-    for (int i = 0; i < D_rows*D_cols; ++i)
-      D_data[i] >> cam_info.D[i];
-  
-    return true;
-  }
-  catch (YAML::Exception& e) {
-    ROS_ERROR("Exception parsing YAML camera calibration:\n%s", e.what());
-    return false;
-  }
-}
-
-bool readCalibrationYml(const std::string& file_name, std::string& camera_name,
+bool readCalibrationYml(std::istream& in,
+                        std::string& camera_name,
                         sensor_msgs::CameraInfo& cam_info)
 {
-  std::ifstream fin(file_name.c_str());
-  if (!fin.good()) {
-    ROS_INFO("Unable to open camera calibration file [%s]", file_name.c_str());
-    return false;
-  }
-  bool success = readCalibrationYml(fin, camera_name, cam_info);
-  if (!success)
-    ROS_ERROR("Failed to parse camera calibration from file [%s]", file_name.c_str());
-  return success;
+    try
+    {
+#ifdef HAVE_NEW_YAMLCPP
+        YAML::Node doc = YAML::Load(in);
+
+        if (doc[CAM_YML_NAME])
+            doc[CAM_YML_NAME] >> camera_name;
+        else
+            camera_name = "unknown";
+#else
+        YAML::Parser parser(in);
+        if (!parser)
+        {
+            ROS_ERROR("Unable to create YAML parser for camera calibration");
+            return false;
+        }
+        YAML::Node doc;
+        parser.GetNextDocument(doc);
+
+        if (const YAML::Node* name_node = doc.FindValue(CAM_YML_NAME))
+            *name_node >> camera_name;
+        else
+            camera_name = "unknown";
+#endif
+
+        doc[WIDTH_YML_NAME] >> cam_info.width;
+        doc[HEIGHT_YML_NAME] >> cam_info.height;
+
+        // Read in fixed-size matrices
+        SimpleMatrix K_(3, 3, &cam_info.K[0]);
+        doc[K_YML_NAME] >> K_;
+        SimpleMatrix R_(3, 3, &cam_info.R[0]);
+        doc[R_YML_NAME] >> R_;
+        SimpleMatrix P_(3, 4, &cam_info.P[0]);
+        doc[P_YML_NAME] >> P_;
+
+        // Different distortion models may have different numbers of parameters
+#ifdef HAVE_NEW_YAMLCPP
+        if (doc[DMODEL_YML_NAME])
+        {
+            doc[DMODEL_YML_NAME] >> cam_info.distortion_model;
+        }
+#else
+        if (const YAML::Node* model_node = doc.FindValue(DMODEL_YML_NAME))
+        {
+            *model_node >> cam_info.distortion_model;
+        }
+#endif
+        else
+        {
+            // Assume plumb bob for backwards compatibility
+            cam_info.distortion_model =
+                sensor_msgs::distortion_models::PLUMB_BOB;
+            ROS_WARN(
+                "Camera calibration file did not specify distortion model, "
+                "assuming plumb bob");
+        }
+        const YAML::Node& D_node = doc[D_YML_NAME];
+        int D_rows, D_cols;
+        D_node["rows"] >> D_rows;
+        D_node["cols"] >> D_cols;
+        const YAML::Node& D_data = D_node["data"];
+        cam_info.D.resize(D_rows * D_cols);
+        for (int i = 0; i < D_rows * D_cols; ++i) D_data[i] >> cam_info.D[i];
+
+        return true;
+    }
+    catch (YAML::Exception& e)
+    {
+        ROS_ERROR("Exception parsing YAML camera calibration:\n%s", e.what());
+        return false;
+    }
 }
 
-} //namespace camera_calibration_parsers
+bool readCalibrationYml(const std::string& file_name,
+                        std::string& camera_name,
+                        sensor_msgs::CameraInfo& cam_info)
+{
+    std::ifstream fin(file_name.c_str());
+    if (!fin.good())
+    {
+        ROS_INFO("Unable to open camera calibration file [%s]",
+                 file_name.c_str());
+        return false;
+    }
+    bool success = readCalibrationYml(fin, camera_name, cam_info);
+    if (!success)
+        ROS_ERROR("Failed to parse camera calibration from file [%s]",
+                  file_name.c_str());
+    return success;
+}
+
+}  // namespace camera_calibration_parsers


### PR DESCRIPTION
## Description

Unfortunately loading the camera calibration parameters from the YAML file is not as trivial in C++ as it is in Python.
Add a parser class which is based on the `camera_calibration_parser` of ROS.


## How I Tested

Using the test executable that is added as well.

## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [ ] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
