### PR TITLE
Rescale images in BGR space

### DIFF
--- a/include/trifinger_cameras/pylon_driver.hpp
+++ b/include/trifinger_cameras/pylon_driver.hpp
@@ -62,6 +62,7 @@ private:
     const bool downsample_images_;
     Pylon::PylonAutoInitTerm auto_init_term_;
     Pylon::CInstantCamera camera_;
+    Pylon::CImageFormatConverter format_converter_;
 
     void set_camera_configuration(GenApi::INodeMap& nodemap);
 };


### PR DESCRIPTION
## Description

Convert raw images to BGR (using the converter of the Pylon SDK),
rescale the image and then reconstruct the Bayer pattern for the
downsampled image.  This results in a better image quality than the
previous method of downsampling the raw data.

## How I Tested

On TriFingerPro.


## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
