### PR TITLE
Add device user ID of the camera to error messages

### DIFF
--- a/include/trifinger_cameras/pylon_driver.hpp
+++ b/include/trifinger_cameras/pylon_driver.hpp
@@ -59,6 +59,7 @@ public:
     CameraObservation get_observation();
 
 private:
+    const std::string device_user_id_;
     const bool downsample_images_;
     Pylon::PylonAutoInitTerm auto_init_term_;
     Pylon::CInstantCamera camera_;

--- a/src/pylon_driver.cpp
+++ b/src/pylon_driver.cpp
@@ -55,7 +55,7 @@ cv::Mat BGR2BayerBG(const cv::Mat& bgr_image)
 
 PylonDriver::PylonDriver(const std::string& device_user_id,
                          bool downsample_images)
-    : downsample_images_(downsample_images)
+    : device_user_id_(device_user_id), downsample_images_(downsample_images)
 {
     Pylon::CTlFactory& tl_factory = Pylon::CTlFactory::GetInstance();
     Pylon::PylonInitialize();
@@ -101,7 +101,8 @@ PylonDriver::PylonDriver(const std::string& device_user_id,
         {
             Pylon::PylonTerminate();
             throw std::runtime_error(
-                "Device id specified doesn't correspond to any "
+                "Device id " + device_user_id_ +
+                " doesn't correspond to any "
                 "connected devices, please retry with a valid id.");
         }
 
@@ -141,7 +142,8 @@ CameraObservation PylonDriver::get_observation()
             ptr_grab_result->GetWidth() / 2 != image_frame.width)
         {
             std::stringstream msg;
-            msg << "Size of grabbed frame (" << ptr_grab_result->GetWidth()
+            msg << device_user_id_ << ": "
+                << "Size of grabbed frame (" << ptr_grab_result->GetWidth()
                 << "x" << ptr_grab_result->GetHeight()
                 << ") does not match expected size (" << image_frame.width * 2
                 << "x" << image_frame.height * 2 << ").";
@@ -188,7 +190,8 @@ CameraObservation PylonDriver::get_observation()
     }
     else
     {
-        throw std::runtime_error("Failed to access images from the camera.");
+        throw std::runtime_error("Failed to access images from camera " +
+                                 device_user_id_ + ".");
     }
 
     return image_frame;


### PR DESCRIPTION
## Description

To make it easier to identify the problematic camera in a multi-camera
setup, add the name (aka device_user_id") of the camera to all error
messages.


## How I Tested

On a TriFingerPro platform.

## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
