### PR TITLE
Suppress the -Wpedantic warnings in the Pylon headers

### DIFF
--- a/include/trifinger_cameras/pylon_driver.hpp
+++ b/include/trifinger_cameras/pylon_driver.hpp
@@ -15,7 +15,11 @@
 #error Cannot use PylonDriver without Pylon.
 #endif
 
+// ignore warnings in the pylon headers
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
 #include <pylon/PylonIncludes.h>
+#pragma GCC diagnostic pop
 
 #include <robot_interfaces/sensors/sensor_driver.hpp>
 #include <trifinger_cameras/camera_observation.hpp>


### PR DESCRIPTION
## Description

Pylon causes a lot of pedantic warnings which clutter the build output.  Since it
is a third-party library (i.e. these warnings are not caused by our own
code), tell GCC to ignore them.


## How I Tested
Clean rebuild of the workspace.


## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
