### PR TITLE
PyBulletTriCameraDriver: Sync with robot data

### DIFF
--- a/include/trifinger_cameras/pybullet_tricamera_driver.hpp
+++ b/include/trifinger_cameras/pybullet_tricamera_driver.hpp
@@ -8,6 +8,7 @@
 
 #include <pybind11/embed.h>
 
+#include <robot_interfaces/finger_types.hpp>
 #include <robot_interfaces/sensors/sensor_driver.hpp>
 #include <trifinger_cameras/tricamera_observation.hpp>
 
@@ -20,7 +21,9 @@ class PyBulletTriCameraDriver : public robot_interfaces::SensorDriver<
                                     trifinger_cameras::TriCameraObservation>
 {
 public:
-    PyBulletTriCameraDriver();
+    PyBulletTriCameraDriver(
+        robot_interfaces::TriFingerTypes::BaseDataPtr robot_data,
+        bool render_images = true);
 
     /**
      * @brief Get the latest observation from the three cameras
@@ -34,6 +37,16 @@ private:
 
     //! @brief The numpy module.
     pybind11::module numpy_;
+
+    //! @brief If false, no images are rendered.  Images in observations will be
+    //!        uninitialised.
+    bool render_images_;
+
+    //! @brief Pointer to robot data, needed for time synchronisation.
+    robot_interfaces::TriFingerTypes::BaseDataPtr robot_data_;
+    //! @brief Last robot time index at which a camera observation was returned.
+    //         Needed for time synchronisation.
+    time_series::Index last_update_robot_time_index_;
 };
 
 }  // namespace trifinger_cameras

--- a/src/pybullet_tricamera_driver.cpp
+++ b/src/pybullet_tricamera_driver.cpp
@@ -16,7 +16,12 @@ namespace py = pybind11;
 
 namespace trifinger_cameras
 {
-PyBulletTriCameraDriver::PyBulletTriCameraDriver()
+PyBulletTriCameraDriver::PyBulletTriCameraDriver(
+    robot_interfaces::TriFingerTypes::BaseDataPtr robot_data,
+    bool render_images)
+    : render_images_(render_images),
+      robot_data_(robot_data),
+      last_update_robot_time_index_(0)
 {
     // initialize Python interpreter if not already done
     if (!Py_IsInitialized())
@@ -26,41 +31,84 @@ PyBulletTriCameraDriver::PyBulletTriCameraDriver()
 
     py::gil_scoped_acquire acquire;
 
-    // some imports that are needed later for converting images (numpy array ->
-    // cv::Mat)
-    numpy_ = py::module::import("numpy");
+    if (render_images)
+    {
+        // some imports that are needed later for converting images (numpy array
+        // -> cv::Mat)
+        numpy_ = py::module::import("numpy");
 
-    // TriFingerCameras gives access to the cameras in simulation
-    py::module mod_camera = py::module::import("trifinger_simulation.camera");
-    cameras_ = mod_camera.attr("TriFingerCameras")();
+        // TriFingerCameras gives access to the cameras in simulation
+        py::module mod_camera =
+            py::module::import("trifinger_simulation.camera");
+        cameras_ = mod_camera.attr("TriFingerCameras")();
+    }
 }
 
 trifinger_cameras::TriCameraObservation
 PyBulletTriCameraDriver::get_observation()
 {
-    auto start_time = std::chrono::system_clock::now();
+    time_series::Index robot_t =
+        robot_data_->observation->newest_timeindex(false);
+    if (robot_t == time_series::EMPTY)
+    {
+        // As long as robot backend did not start yet, run at around 10 Hz
+        using namespace std::chrono_literals;
+        std::this_thread::sleep_for(100ms);
+    }
+    else
+    {
+        // Synchronize with robot backend:  To achieve 10 Hz, there should be
+        // one camera observation every 100 robot steps.
+        while (robot_t < last_update_robot_time_index_ + 100)
+        {
+            using namespace std::chrono_literals;
+            std::this_thread::sleep_for(10ms);
+            auto new_robot_t =
+                robot_data_->observation->newest_timeindex(false);
 
-    trifinger_cameras::TriCameraObservation tricam_obs;
+            // If robot t did not increase, assume the robot has stopped.
+            // Break this loop to avoid a dead-lock.
+            if (new_robot_t == robot_t)
+            {
+                break;
+            }
+            robot_t = new_robot_t;
+        }
+        last_update_robot_time_index_ = robot_t;
+    }
+
+    trifinger_cameras::TriCameraObservation observation;
+
+    auto current_time = std::chrono::system_clock::now();
+    double timestamp =
+        std::chrono::duration<double>(current_time.time_since_epoch()).count();
+    for (int i = 0; i < 3; i++)
+    {
+        observation.cameras[i].timestamp = timestamp;
+    }
 
     {
         py::gil_scoped_acquire acquire;
 
-        py::list images = cameras_.attr("get_bayer_images")();
-        for (int i = 0; i < 3; i++)
+        // skip the rendering if render_images_ == false.  In this case the
+        // images in the observation will simply be uninitialised.
+        if (render_images_)
         {
-            // ensure that the image array is contiguous in memory, otherwise
-            // conversion to cv::Mat would fail
-            auto image = numpy_.attr("ascontiguousarray")(images[i]);
-            // convert to cv::Mat
-            tricam_obs.cameras[i].image = image.cast<cv::Mat>();
+            py::list images = cameras_.attr("get_bayer_images")();
+            for (int i = 0; i < 3; i++)
+            {
+                // ensure that the image array is contiguous in memory,
+                // otherwise conversion to cv::Mat would fail
+                auto image = numpy_.attr("ascontiguousarray")(images[i]);
+                cv::Mat image_cv = image.cast<cv::Mat>();
+                // explicitly copy to ensure it is not pointing to some data
+                // that later gets invalid
+                image_cv.copyTo(observation.cameras[i].image);
+            }
         }
     }
 
-    // run at around 10 Hz
-    using namespace std::chrono_literals;
-    std::this_thread::sleep_until(start_time + 100ms);
-
-    return tricam_obs;
+    return observation;
 }
 
 }  // namespace trifinger_cameras

--- a/srcpy/py_tricamera_types.cpp
+++ b/srcpy/py_tricamera_types.cpp
@@ -44,6 +44,9 @@ PYBIND11_MODULE(py_tricamera_types, m)
                      std::shared_ptr<PyBulletTriCameraDriver>,
                      SensorDriver<TriCameraObservation>>(
         m, "PyBulletTriCameraDriver")
-        .def(pybind11::init<>())
+        .def(pybind11::init<robot_interfaces::TriFingerTypes::BaseDataPtr,
+                            bool>(),
+             pybind11::arg("robot_data"),
+             pybind11::arg("render_images") = true)
         .def("get_observation", &PyBulletTriCameraDriver::get_observation);
 }


### PR DESCRIPTION
## Description

Pass RobotData pointer to the PyBulletTriCameraDriver and us its
`newest_timeindex` as clock, so that the rate of robot and camera is
synchronised even if the simulation is not running in real time.

This is mostly copy&paste from the corresponding driver in
trifinger_object_tracking.


## How I Tested

By running an episode in simulation, using this driver and checking if the camera timing makes sense by replaying the logs using TriFingerPlatformLog.


## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
