### PR TITLE
record_image_dataset: Do not downsample by default

### DIFF
--- a/scripts/record_image_dataset.py
+++ b/scripts/record_image_dataset.py
@@ -100,9 +100,9 @@ def main():
         """,
     )
     argparser.add_argument(
-        "--no-downsample",
+        "--downsample",
         action="store_true",
-        help="""Do not downsample images.  Only for Pylon cameras.""",
+        help="""Downsample images by factor 2.  Only for Pylon cameras.""",
     )
     args = argparser.parse_args()
 
@@ -113,13 +113,13 @@ def main():
     if args.driver == "tri":
         camera_names = ["camera60", "camera180", "camera300"]
         camera_driver = trifinger_cameras.tricamera.TriCameraDriver(
-            *camera_names, not args.no_downsample
+            *camera_names, args.downsample
         )
         camera_module = trifinger_cameras.tricamera
         image_saver = TriImageSaver(args.outdir, camera_names)
     elif args.driver == "pylon":
         camera_driver = trifinger_cameras.camera.PylonDriver(
-            args.camera_id, not args.no_downsample
+            args.camera_id, args.downsample
         )
         camera_module = trifinger_cameras.camera
         image_saver = SingleImageSaver(args.outdir, args.camera_id)
@@ -131,7 +131,7 @@ def main():
         image_saver = SingleImageSaver(args.outdir, args.camera_id)
 
     camera_data = camera_module.SingleProcessData()
-    camera_backend = camera_module.Backend(camera_driver, camera_data)  # noqa
+    camera_backend = camera_module.Backend(camera_driver, camera_data)
     camera_frontend = camera_module.Frontend(camera_data)
 
     while True:
@@ -162,6 +162,8 @@ def main():
 
         observation = camera_frontend.get_latest_observation()
         image_saver.save(observation)
+
+    camera_backend.shutdown()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION


[//]: # "Thanks for your contribution.  To make life of the reviewers easier,"
[//]: # "please give this pull request a meaningful title and provide the"
[//]: # "requested information below."

## Description

Replace the `--no-downsample` argument with `--downsample`, that is do
not downsample by default but only when explicitly requested.

The reasoning is that this way the damage is much smaller when
accidentally omitting the argument (full-sized images can still be
downsampled later without loss of information).

Also properly shut down the camera_backend in the end.


## How I Tested

By running it with and without `--downsample` and checking the resulting images.



## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
