### PR TITLE
chore: Build with "robot" image (contains Pylon)

### DIFF
--- a/.github/workflows/build_master.yml
+++ b/.github/workflows/build_master.yml
@@ -36,6 +36,11 @@ jobs:
 
       - name: Setup Apptainer
         uses: open-dynamic-robot-initiative/trifinger-build-action/setup_apptainer@v1
+        with:
+          # use the "robot" image (which contains Pylon) but rename to "user" so
+          # following steps can work with default values
+          uri: oras://ghcr.io/open-dynamic-robot-initiative/trifinger_singularity/trifinger_robot:latest
+          output_file: trifinger_user_latest.sif
 
       - name: Build
         uses: open-dynamic-robot-initiative/trifinger-build-action/build@v1

--- a/.github/workflows/build_pr.yml
+++ b/.github/workflows/build_pr.yml
@@ -22,6 +22,11 @@ jobs:
 
       - name: Setup Apptainer
         uses: open-dynamic-robot-initiative/trifinger-build-action/setup_apptainer@v1
+        with:
+          # use the "robot" image (which contains Pylon) but rename to "user" so
+          # following steps can work with default values
+          uri: oras://ghcr.io/open-dynamic-robot-initiative/trifinger_singularity/trifinger_robot:latest
+          output_file: trifinger_user_latest.sif
 
       - name: Build
         uses: open-dynamic-robot-initiative/trifinger-build-action/build@v1


### PR DESCRIPTION


[//]: # "Thanks for your contribution.  To make life of the reviewers easier,"
[//]: # "please give this pull request a meaningful title and provide the"
[//]: # "requested information below."

## Description

The standard trifinger_user image does not contain Pylon and thus the Pylon drivers won't get built using that image.  Switch to the "robot" image which includes Pylon.
