### PR TITLE
Adjust default edge mean threshold

### DIFF
--- a/scripts/check_camera_sharpness.py
+++ b/scripts/check_camera_sharpness.py
@@ -105,7 +105,7 @@ def main():
         "--threshold",
         "-t",
         type=float,
-        default=12.0,
+        default=10.0,
         help="""Threshold for the edge mean.  Images with an 'edge mean' below this
             threshold are marked as too blurry.  Default: %(default)s.
         """,


### PR DESCRIPTION
Adjust the default threshold in check_camera_sharpness to match with what is currently used in the robot self-test.