### PR TITLE
Implement get_sensor_info() for Pylon (single and tri) and PyBullet drivers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@
   [documentation](https://open-dynamic-robot-initiative.github.io/trifinger_cameras/doc/configuration.html)
 - Executable `tricamera_monitor_rate` for checking the actual frame rate (most meant for
   debugging and testing during development)
+- Executables `single_camera_backend` and `tricamera_backend` to run camera back ends in
+  a separate process (mostly for testing).  Also added `--multi-process` option to
+  `demo_camera.py` accordingly.
+- Implement `get_sensor_info()` for Pylon and PyBullet drivers.  See `demo_camera` and
+  `demo_tricamera` on how to use it.
 
 ### Removed
 - Obsolete script `verify_calibration.py`

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -281,11 +281,12 @@ install_scripts(
     scripts/overlay_camera_stream.py
     scripts/overlay_real_and_rendered_images.py
     scripts/record_image_dataset.py
+    scripts/single_camera_backend.py
+    scripts/tricamera_backend.py
     scripts/tricamera_log_converter.py
     scripts/tricamera_log_viewer.py
     scripts/tricamera_monitor_rate.py
     scripts/tricamera_test_connection.py
-
     DESTINATION lib/${PROJECT_NAME}
 )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,9 @@ set(CMAKE_CXX_STANDARD_REQUIRED on)
 # libraries need to be position independent for building Python modules
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
+# generate compile_commands.json by default (needed for LSP)
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/cmake)
 
 # pybind11 needs to be first, otherwise other packages which also search for

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,7 +78,10 @@ target_link_libraries(camera_observations
 list(APPEND install_targets camera_observations)
 
 
-add_library(opencv_driver src/opencv_driver.cpp)
+add_library(opencv_driver
+    src/opencv_driver.cpp
+    src/camera_parameters.cpp
+)
 target_include_directories(opencv_driver PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
     $<INSTALL_INTERFACE:include>
@@ -87,13 +90,17 @@ target_include_directories(opencv_driver PUBLIC
 target_link_libraries(opencv_driver
     ${OpenCV_LIBRARIES}
     robot_interfaces::robot_interfaces
+    serialization_utils::serialization_utils
     camera_observations
 )
 list(APPEND install_targets opencv_driver)
 
 
 if (${Pylon_FOUND})
-    add_library(pylon_driver src/pylon_driver.cpp)
+    add_library(pylon_driver
+        src/pylon_driver.cpp
+        src/camera_parameters.cpp
+    )
     target_include_directories(pylon_driver PUBLIC
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
         $<INSTALL_INTERFACE:include>
@@ -105,6 +112,7 @@ if (${Pylon_FOUND})
         ${Pylon_LIBRARIES}
         fmt::fmt
         robot_interfaces::robot_interfaces
+        serialization_utils::serialization_utils
         camera_observations
         settings
     )
@@ -199,7 +207,10 @@ target_include_directories(camera_calibration_parser PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
     $<INSTALL_INTERFACE:include>
 )
-target_link_libraries(camera_calibration_parser yaml_utils::yaml_utils)
+target_link_libraries(camera_calibration_parser
+    serialization_utils::serialization_utils
+    yaml_utils::yaml_utils
+)
 ament_target_dependencies(camera_calibration_parser
     sensor_msgs
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,9 @@ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 # generate compile_commands.json by default (needed for LSP)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
+# stop build on first error
+string(APPEND CMAKE_CXX_FLAGS " -Wfatal-errors -Werror=return-type")
+
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/cmake)
 
 # pybind11 needs to be first, otherwise other packages which also search for
@@ -116,6 +119,7 @@ if (${Pylon_FOUND})
         fmt::fmt
         robot_interfaces::robot_interfaces
         serialization_utils::serialization_utils
+        camera_calibration_parser
         camera_observations
         settings
     )

--- a/demos/demo_camera.py
+++ b/demos/demo_camera.py
@@ -6,6 +6,7 @@ as a non-real time livestream.
 Basically illustrates what objects to create to interact with the
 camera, and the available methods for that.
 """
+
 import argparse
 import sys
 
@@ -15,7 +16,7 @@ import trifinger_cameras
 from trifinger_cameras import utils
 
 
-def main() -> int:
+def main() -> int:  # noqa: D103
     argparser = argparse.ArgumentParser(description=__doc__)
     argparser.add_argument(
         "--pylon",
@@ -71,6 +72,16 @@ def main() -> int:
     if args.record:
         logger = trifinger_cameras.camera.Logger(camera_data, 10000)
         logger.start()
+
+    print("--- Camera Info: ----------------------")
+    sinfo = camera_frontend.get_sensor_info()
+    print(f"fps: {sinfo.frame_rate_fps}")
+    print(f"width: {sinfo.image_width}")
+    print(f"height: {sinfo.image_height}")
+    print(sinfo.camera_matrix)
+    print(sinfo.distortion_coefficients)
+    print(sinfo.tf_world_to_camera)
+    print("---------------------------------------")
 
     while True:
         observation = camera_frontend.get_latest_observation()

--- a/demos/demo_camera.py
+++ b/demos/demo_camera.py
@@ -12,6 +12,7 @@ import pathlib
 import sys
 
 import cv2
+import numpy as np
 
 import trifinger_cameras
 from trifinger_cameras import utils
@@ -86,11 +87,11 @@ def main() -> int:  # noqa: D103
         logger = trifinger_cameras.camera.Logger(camera_data, 10000)
         logger.start()
 
+    np.set_printoptions(precision=3, suppress=True)
     print("--- Camera Info: ----------------------")
     sinfo = camera_frontend.get_sensor_info()
     print(f"fps: {sinfo.frame_rate_fps}")
-    print(f"width: {sinfo.image_width}")
-    print(f"height: {sinfo.image_height}")
+    print(f"width x height: {sinfo.image_width}x{sinfo.image_height}")
     print(sinfo.camera_matrix)
     print(sinfo.distortion_coefficients)
     print(sinfo.tf_world_to_camera)

--- a/demos/demo_camera.py
+++ b/demos/demo_camera.py
@@ -8,6 +8,7 @@ camera, and the available methods for that.
 """
 
 import argparse
+import pathlib
 import sys
 
 import cv2
@@ -30,6 +31,13 @@ def main() -> int:  # noqa: D103
         help="""ID of the camera that is used.  If --pylon is set this refers
             to the DeviceUserId, otherwise it is the index of the device.
         """,
+    )
+    argparser.add_argument(
+        "--camera-info",
+        type=pathlib.Path,
+        metavar="<file>",
+        dest="camera_info_file",
+        help="Path to YAML file with camera calibration data.",
     )
     argparser.add_argument(
         "--multi-process",
@@ -55,7 +63,12 @@ def main() -> int:  # noqa: D103
 
         try:
             if args.pylon:
-                camera_driver = trifinger_cameras.camera.PylonDriver(args.camera_id)
+                if args.camera_info_file:
+                    camera_driver = trifinger_cameras.camera.PylonDriver(
+                        args.camera_info_file
+                    )
+                else:
+                    camera_driver = trifinger_cameras.camera.PylonDriver(args.camera_id)
             else:
                 camera_id = int(args.camera_id) if args.camera_id else 0
                 camera_driver = trifinger_cameras.camera.OpenCVDriver(camera_id)

--- a/demos/demo_camera.py
+++ b/demos/demo_camera.py
@@ -99,7 +99,10 @@ def main() -> int:  # noqa: D103
 
     while True:
         observation = camera_frontend.get_latest_observation()
-        image = utils.convert_image(observation.image)
+        if args.pylon:
+            image = utils.convert_image(observation.image)
+        else:
+            image = observation.image
         window_name = "Image Stream"
         cv2.imshow(window_name, image)
 

--- a/demos/demo_camera.py
+++ b/demos/demo_camera.py
@@ -31,6 +31,13 @@ def main() -> int:
         """,
     )
     argparser.add_argument(
+        "--multi-process",
+        action="store_true",
+        help="""If set, run only front end with multi-process robot data.  Otherwise run
+            everything within a single process.
+        """,
+    )
+    argparser.add_argument(
         "--record",
         type=str,
         help="""Path to file in which camera data is recorded.""",
@@ -38,22 +45,27 @@ def main() -> int:
 
     args = argparser.parse_args()
 
-    camera_data = trifinger_cameras.camera.SingleProcessData()
-    # camera_data = trifinger_cameras.camera.MultiProcessData("cam", True, 10)
+    if args.multi_process:
+        # In multi-process case assume that the backend is running in a
+        # separate process and only set up the frontend here.
+        camera_data = trifinger_cameras.camera.MultiProcessData("camera", False)
+    else:
+        camera_data = trifinger_cameras.camera.SingleProcessData()
 
-    try:
-        if args.pylon:
-            camera_driver = trifinger_cameras.camera.PylonDriver(args.camera_id)
-        else:
-            camera_id = int(args.camera_id) if args.camera_id else 0
-            camera_driver = trifinger_cameras.camera.OpenCVDriver(camera_id)
-    except Exception as e:
-        print("Failed to initialise driver:", e)
-        return 1
+        try:
+            if args.pylon:
+                camera_driver = trifinger_cameras.camera.PylonDriver(args.camera_id)
+            else:
+                camera_id = int(args.camera_id) if args.camera_id else 0
+                camera_driver = trifinger_cameras.camera.OpenCVDriver(camera_id)
+        except Exception as e:
+            print("Failed to initialise driver:", e)
+            return 1
 
-    camera_backend = trifinger_cameras.camera.Backend(  # noqa: F841
-        camera_driver, camera_data
-    )
+        camera_backend = trifinger_cameras.camera.Backend(  # noqa: F841
+            camera_driver, camera_data
+        )
+
     camera_frontend = trifinger_cameras.camera.Frontend(camera_data)
 
     if args.record:

--- a/demos/demo_tricamera.py
+++ b/demos/demo_tricamera.py
@@ -6,8 +6,10 @@ cameras are in sync with each other.
 """
 
 import argparse
-import cv2
 import pickle
+
+import cv2
+import numpy as np
 
 import trifinger_cameras
 from trifinger_cameras import utils
@@ -45,6 +47,18 @@ def main() -> None:  # noqa: D103
 
     camera_frontend = trifinger_cameras.tricamera.Frontend(camera_data)
     observations_timestamps_list = []
+
+    np.set_printoptions(precision=3, suppress=True)
+    print("=== Camera Info: ======================")
+    for i, info in enumerate(camera_frontend.get_sensor_info().camera):
+        print(f"--- Camera {i}: ----------------------")
+        print(f"fps: {info.frame_rate_fps}")
+        print(f"width x height: {info.image_width}x{info.image_height}")
+        print(info.camera_matrix)
+        print(info.distortion_coefficients)
+        print(info.tf_world_to_camera)
+        print("---------------------------------------")
+    print("=======================================")
 
     while True:
         observation = camera_frontend.get_latest_observation()

--- a/doc/executables.rst
+++ b/doc/executables.rst
@@ -142,3 +142,11 @@ Usage (saving the settings to a file "camera_settings.txt":
 .. code-block:: sh
 
    $ pylon_dump_camera_settings "device_user_id" > camera_settings.txt
+
+
+single_camera_backend / tricamera_backend
+=========================================
+
+Run a back end instance for a single camera / the TriCamera setup.  Multi-process sensor
+data is used so other processes can connect with a front end to acquire the images (see
+`demo_camera` / `demo_tricamera`).

--- a/include/trifinger_cameras/camera_parameters.hpp
+++ b/include/trifinger_cameras/camera_parameters.hpp
@@ -12,7 +12,6 @@
 
 #include <serialization_utils/cereal_eigen.hpp>
 
-
 namespace trifinger_cameras
 {
 struct CameraParameters
@@ -34,12 +33,11 @@ struct CameraParameters
                 CEREAL_NVP(distortion_coefficients),
                 CEREAL_NVP(tf_world_to_camera));
     }
-
 };
 
 std::ostream& operator<<(std::ostream& os, const CameraParameters& cp);
 
-struct CameraInfo: public CameraParameters
+struct CameraInfo : public CameraParameters
 {
     float frame_rate_fps;
 
@@ -48,6 +46,24 @@ struct CameraInfo: public CameraParameters
     {
         CameraParameters::serialize(archive);
         archive(CEREAL_NVP(frame_rate_fps));
+    }
+};
+
+struct TriCameraInfo
+{
+    std::array<CameraInfo, 3> camera;
+
+    TriCameraInfo() = default;
+
+    TriCameraInfo(CameraInfo camera1, CameraInfo camera2, CameraInfo camera3)
+        : camera{camera1, camera2, camera3}
+    {
+    }
+
+    template <class Archive>
+    void serialize(Archive& archive)
+    {
+        archive(CEREAL_NVP(camera));
     }
 };
 

--- a/include/trifinger_cameras/camera_parameters.hpp
+++ b/include/trifinger_cameras/camera_parameters.hpp
@@ -5,8 +5,13 @@
  */
 #pragma once
 
-#include <Eigen/Eigen>
 #include <ostream>
+#include <string>
+
+#include <Eigen/Eigen>
+
+#include <serialization_utils/cereal_eigen.hpp>
+
 
 namespace trifinger_cameras
 {
@@ -19,8 +24,31 @@ struct CameraParameters
     Eigen::Matrix<double, 1, 5> distortion_coefficients;
 
     Eigen::Matrix4d tf_world_to_camera;
+
+    template <class Archive>
+    void serialize(Archive& archive)
+    {
+        archive(CEREAL_NVP(image_width),
+                CEREAL_NVP(image_height),
+                CEREAL_NVP(camera_matrix),
+                CEREAL_NVP(distortion_coefficients),
+                CEREAL_NVP(tf_world_to_camera));
+    }
+
 };
 
 std::ostream& operator<<(std::ostream& os, const CameraParameters& cp);
+
+struct CameraInfo: public CameraParameters
+{
+    float frame_rate_fps;
+
+    template <class Archive>
+    void serialize(Archive& archive)
+    {
+        CameraParameters::serialize(archive);
+        archive(CEREAL_NVP(frame_rate_fps));
+    }
+};
 
 }  // namespace trifinger_cameras

--- a/include/trifinger_cameras/opencv_driver.hpp
+++ b/include/trifinger_cameras/opencv_driver.hpp
@@ -21,8 +21,6 @@ class OpenCVDriver
 public:
     OpenCVDriver(int device_id);
 
-    // FIXME: implement get_sensor_info()
-
     /**
      * @brief Grab a single frame along with its timestamp.
      *

--- a/include/trifinger_cameras/opencv_driver.hpp
+++ b/include/trifinger_cameras/opencv_driver.hpp
@@ -8,16 +8,20 @@
 
 #include <robot_interfaces/sensors/sensor_driver.hpp>
 #include <trifinger_cameras/camera_observation.hpp>
+#include <trifinger_cameras/camera_parameters.hpp>
 
 namespace trifinger_cameras
 {
 /**
  * @brief Driver for interacting with any camera using OpenCV.
  */
-class OpenCVDriver : public robot_interfaces::SensorDriver<CameraObservation>
+class OpenCVDriver
+    : public robot_interfaces::SensorDriver<CameraObservation, CameraInfo>
 {
 public:
     OpenCVDriver(int device_id);
+
+    // FIXME: implement get_sensor_info()
 
     /**
      * @brief Grab a single frame along with its timestamp.

--- a/include/trifinger_cameras/pybullet_tricamera_driver.hpp
+++ b/include/trifinger_cameras/pybullet_tricamera_driver.hpp
@@ -10,6 +10,7 @@
 
 #include <robot_interfaces/finger_types.hpp>
 #include <robot_interfaces/sensors/sensor_driver.hpp>
+#include <trifinger_cameras/camera_parameters.hpp>
 #include <trifinger_cameras/settings.hpp>
 #include <trifinger_cameras/tricamera_observation.hpp>
 
@@ -18,14 +19,16 @@ namespace trifinger_cameras
 /**
  * @brief Driver to get rendered camera images from pyBullet.
  */
-class PyBulletTriCameraDriver : public robot_interfaces::SensorDriver<
-                                    trifinger_cameras::TriCameraObservation>
+class PyBulletTriCameraDriver
+    : public robot_interfaces::SensorDriver<TriCameraObservation, TriCameraInfo>
 {
 public:
     PyBulletTriCameraDriver(
         robot_interfaces::TriFingerTypes::BaseDataPtr robot_data,
         bool render_images = true,
         Settings settings = Settings());
+
+    // FIXME: Implement get_sensor_info()
 
     /**
      * @brief Get the latest observation from the three cameras

--- a/include/trifinger_cameras/pybullet_tricamera_driver.hpp
+++ b/include/trifinger_cameras/pybullet_tricamera_driver.hpp
@@ -28,13 +28,21 @@ public:
         bool render_images = true,
         Settings settings = Settings());
 
-    // FIXME: Implement get_sensor_info()
+    /**
+     * @brief Get the camera parameters (image size and calibration
+     * coefficients).
+     *
+     * **Important:**  The calibration coefficients are only set if the driver
+     * is initialized with a calibration file (see constructor).  Otherwise,
+     * they will be empty.
+     */
+    virtual TriCameraInfo get_sensor_info() override;
 
     /**
      * @brief Get the latest observation from the three cameras
      * @return TricameraObservation
      */
-    trifinger_cameras::TriCameraObservation get_observation();
+    virtual trifinger_cameras::TriCameraObservation get_observation() override;
 
 private:
     //! @brief Python object to access cameras in pyBullet.
@@ -55,6 +63,9 @@ private:
 
     //! Number of robot time steps after which the next frame should be fetched.
     int frame_rate_in_robot_steps_;
+
+    //! Sensor info for the cameras.
+    TriCameraInfo sensor_info_ = {};
 };
 
 }  // namespace trifinger_cameras

--- a/include/trifinger_cameras/pylon_driver.hpp
+++ b/include/trifinger_cameras/pylon_driver.hpp
@@ -100,9 +100,9 @@ public:
      * @brief Get the camera parameters (image size and calibration
      * coefficients).
      *
-     * **Important:**  The calibration coefficients are only set if the driver is
-     * initialized with a calibration file (see constructor).  Otherwise, they will be
-     * empty.
+     * **Important:**  The calibration coefficients are only set if the driver
+     * is initialized with a calibration file (see constructor).  Otherwise,
+     * they will be empty.
      */
     virtual CameraInfo get_sensor_info() override;
 

--- a/include/trifinger_cameras/pylon_driver.hpp
+++ b/include/trifinger_cameras/pylon_driver.hpp
@@ -23,6 +23,7 @@
 
 #include <robot_interfaces/sensors/sensor_driver.hpp>
 #include <trifinger_cameras/camera_observation.hpp>
+#include <trifinger_cameras/camera_parameters.hpp>
 #include <trifinger_cameras/settings.hpp>
 
 namespace trifinger_cameras
@@ -43,7 +44,8 @@ void pylon_connect(std::string_view device_user_id,
  * @brief Driver for interacting with a camera via Pylon and storing
  * images using OpenCV.
  */
-class PylonDriver : public robot_interfaces::SensorDriver<CameraObservation>
+class PylonDriver
+    : public robot_interfaces::SensorDriver<CameraObservation, CameraInfo>
 {
 public:
     /**
@@ -69,11 +71,17 @@ public:
     static cv::Mat downsample_raw_image(const cv::Mat& image);
 
     /**
+     * @brief Get the camera parameters (image size and calibration
+     * coefficients).
+     */
+    virtual CameraInfo get_sensor_info() override;
+
+    /**
      * @brief Get the latest observation (image frame + timestamp of when the
      * frame's grabbed).
      * @return CameraObservation
      */
-    CameraObservation get_observation();
+    virtual CameraObservation get_observation() override;
 
 private:
     std::shared_ptr<const PylonDriverSettings> settings_;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,5 +7,6 @@ disable = "C0330, C0326"
 module = [
     "cv2",
     "trifinger_cameras.*",
+    "signal_handler",
 ]
 ignore_missing_imports = true

--- a/scripts/single_camera_backend.py
+++ b/scripts/single_camera_backend.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Run back-end for a single camera, using multi-process robot data."""
+"""Run back-end for a single camera, using multi-process data."""
 
 import argparse
 import logging

--- a/scripts/single_camera_backend.py
+++ b/scripts/single_camera_backend.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""Run back-end for a single camera, using multi-process robot data."""
+
+import argparse
+import logging
+import sys
+import time
+
+import signal_handler
+import trifinger_cameras
+
+
+def parse_arguments() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--pylon",
+        action="store_true",
+        help="""Access the camera via Pylon.  If not set, OpenCV is used.""",
+    )
+    parser.add_argument(
+        "--camera-id",
+        "-c",
+        default="",
+        help="""ID of the camera that is used.  If --pylon is set this refers
+            to the DeviceUserId, otherwise it is the index of the device.
+        """,
+    )
+    args = parser.parse_args()
+
+    # === configure logging
+
+    log_handler = logging.StreamHandler(sys.stdout)
+    logging.basicConfig(
+        format="[%(levelname)s %(asctime)s] %(message)s",
+        level=logging.DEBUG,
+        handlers=[log_handler],
+    )
+
+    return args
+
+
+def main() -> int:
+    args = parse_arguments()
+
+    try:
+        if args.pylon:
+            camera_driver = trifinger_cameras.camera.PylonDriver(args.camera_id)
+        else:
+            camera_id = int(args.camera_id) if args.camera_id else 0
+            camera_driver = trifinger_cameras.camera.OpenCVDriver(camera_id)
+    except Exception as e:
+        logging.error("Failed to initialise driver: %s", e)
+        return 1
+
+    logging.info("Start camera backend")
+
+    CAMERA_TIME_SERIES_LENGTH = 1000
+    camera_data = trifinger_cameras.camera.MultiProcessData(
+        "camera", True, CAMERA_TIME_SERIES_LENGTH
+    )
+    camera_backend = trifinger_cameras.camera.Backend(camera_driver, camera_data)
+
+    logging.info("Camera backend ready.")
+
+    signal_handler.init()
+    while not signal_handler.has_received_sigint():
+        time.sleep(1)
+
+    camera_backend.shutdown()
+
+    return 0
+
+
+if __name__ == "__main__":
+    returncode = main()
+    sys.exit(returncode)

--- a/scripts/tricamera_backend.py
+++ b/scripts/tricamera_backend.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""Run back-end for the tricamera setup, using multi-process data."""
+
+import argparse
+import logging
+import pathlib
+import sys
+import time
+
+import signal_handler
+import trifinger_cameras
+
+
+def parse_arguments() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "parameter_file_camera60",
+        type=pathlib.Path,
+        help="Parameter file for camera60.",
+    )
+    parser.add_argument(
+        "parameter_file_camera180",
+        type=pathlib.Path,
+        help="Parameter file for camera180.",
+    )
+    parser.add_argument(
+        "parameter_file_camera300",
+        type=pathlib.Path,
+        help="Parameter file for camera180.",
+    )
+    parser.add_argument(
+        "--verbose", "-v", action="store_true", help="Enable verbose output."
+    )
+    args = parser.parse_args()
+
+    # === configure logging
+
+    log_handler = logging.StreamHandler(sys.stdout)
+    logging.basicConfig(
+        format="[%(levelname)s %(asctime)s] %(message)s",
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        handlers=[log_handler],
+    )
+
+    return args
+
+
+def main() -> int:
+    args = parse_arguments()
+
+    try:
+        camera_driver = trifinger_cameras.tricamera.TriCameraDriver(
+            args.parameter_file_camera60,
+            args.parameter_file_camera180,
+            args.parameter_file_camera300,
+        )
+    except Exception as e:
+        logging.error("Failed to initialise driver: %s", e)
+        return 1
+
+    logging.info("Start camera backend")
+
+    CAMERA_TIME_SERIES_LENGTH = 100
+    camera_data = trifinger_cameras.tricamera.MultiProcessData(
+        "tricamera", True, CAMERA_TIME_SERIES_LENGTH
+    )
+    camera_backend = trifinger_cameras.tricamera.Backend(camera_driver, camera_data)
+
+    logging.info("Camera backend ready.")
+
+    signal_handler.init()
+    while not signal_handler.has_received_sigint():
+        time.sleep(1)
+
+    camera_backend.shutdown()
+
+    return 0
+
+
+if __name__ == "__main__":
+    returncode = main()
+    sys.exit(returncode)

--- a/src/pylon_driver.cpp
+++ b/src/pylon_driver.cpp
@@ -143,6 +143,33 @@ PylonDriver::~PylonDriver()
     Pylon::PylonTerminate();
 }
 
+CameraInfo PylonDriver::get_sensor_info()
+{
+    CameraInfo camera_info;
+
+    GenApi::INodeMap& nodemap = camera_.GetNodeMap();
+
+    camera_info.frame_rate_fps =
+        Pylon::CFloatParameter(nodemap, "AcquisitionFrameRate").GetValue();
+
+    camera_info.image_width =
+        Pylon::CIntegerParameter(nodemap, "Width").GetValue();
+    camera_info.image_height =
+        Pylon::CIntegerParameter(nodemap, "Height").GetValue();
+    if (downsample_images_)
+    {
+        camera_info.image_width /= 2;
+        camera_info.image_height /= 2;
+    }
+
+    // FIXME
+    camera_info.camera_matrix = Eigen::Matrix3d::Identity();
+    camera_info.distortion_coefficients = Eigen::Matrix<double, 1, 5>::Zero();
+    camera_info.tf_world_to_camera = Eigen::Matrix4d::Ones() * 9;
+
+    return camera_info;
+}
+
 CameraObservation PylonDriver::get_observation()
 {
     CameraObservation image_frame;

--- a/src/tricamera_driver.cpp
+++ b/src/tricamera_driver.cpp
@@ -66,8 +66,8 @@ void TriCameraDriver::init(Settings settings)
     rate = std::chrono::milliseconds(std::lround(rate_sec * 1000));
 
     sensor_info_ = TriCameraInfo(camera1_.get_sensor_info(),
-                         camera2_.get_sensor_info(),
-                         camera3_.get_sensor_info());
+                                 camera2_.get_sensor_info(),
+                                 camera3_.get_sensor_info());
     sensor_info_.camera[0].frame_rate_fps = cfg->frame_rate_fps;
     sensor_info_.camera[1].frame_rate_fps = cfg->frame_rate_fps;
     sensor_info_.camera[2].frame_rate_fps = cfg->frame_rate_fps;

--- a/src/tricamera_driver.cpp
+++ b/src/tricamera_driver.cpp
@@ -22,9 +22,27 @@ TriCameraDriver::TriCameraDriver(const std::string& device_id_1,
       camera2_(device_id_2, downsample_images, settings),
       camera3_(device_id_3, downsample_images, settings)
 {
-    auto cfg = Settings().get_tricamera_driver_settings();
-    float rate_sec = 1.f / cfg->frame_rate_fps;
-    rate = std::chrono::milliseconds(std::lround(rate_sec * 1000));
+    init(settings);
+}
+
+TriCameraDriver::TriCameraDriver(
+    const std::filesystem::path& camera_calibration_file_1,
+    const std::filesystem::path& camera_calibration_file_2,
+    const std::filesystem::path& camera_calibration_file_3,
+    bool downsample_images,
+    Settings settings)
+
+    : last_update_time_(std::chrono::system_clock::now()),
+      camera1_(camera_calibration_file_1, downsample_images, settings),
+      camera2_(camera_calibration_file_2, downsample_images, settings),
+      camera3_(camera_calibration_file_3, downsample_images, settings)
+{
+    init(settings);
+}
+
+TriCameraInfo TriCameraDriver::get_sensor_info()
+{
+    return sensor_info_;
 }
 
 TriCameraObservation TriCameraDriver::get_observation()
@@ -39,6 +57,20 @@ TriCameraObservation TriCameraDriver::get_observation()
     tricam_obs.cameras[2] = camera3_.get_observation();
 
     return tricam_obs;
+}
+
+void TriCameraDriver::init(Settings settings)
+{
+    auto cfg = settings.get_tricamera_driver_settings();
+    float rate_sec = 1.f / cfg->frame_rate_fps;
+    rate = std::chrono::milliseconds(std::lround(rate_sec * 1000));
+
+    sensor_info_ = TriCameraInfo(camera1_.get_sensor_info(),
+                         camera2_.get_sensor_info(),
+                         camera3_.get_sensor_info());
+    sensor_info_.camera[0].frame_rate_fps = cfg->frame_rate_fps;
+    sensor_info_.camera[1].frame_rate_fps = cfg->frame_rate_fps;
+    sensor_info_.camera[2].frame_rate_fps = cfg->frame_rate_fps;
 }
 
 }  // namespace trifinger_cameras

--- a/srcpy/py_camera_types.cpp
+++ b/srcpy/py_camera_types.cpp
@@ -8,6 +8,7 @@
 #include <pybind11_opencv/cvbind.hpp>
 
 #include <trifinger_cameras/camera_observation.hpp>
+#include <trifinger_cameras/camera_parameters.hpp>
 #include <trifinger_cameras/opencv_driver.hpp>
 #include <trifinger_cameras/settings.hpp>
 #ifdef Pylon_FOUND
@@ -21,18 +22,20 @@ using namespace trifinger_cameras;
 
 PYBIND11_MODULE(py_camera_types, m)
 {
-    create_sensor_bindings<CameraObservation>(m);
+    create_sensor_bindings<CameraObservation, CameraInfo>(m);
 
     pybind11::class_<OpenCVDriver,
                      std::shared_ptr<OpenCVDriver>,
-                     SensorDriver<CameraObservation>>(m, "OpenCVDriver")
+                     SensorDriver<CameraObservation, CameraInfo>>(
+        m, "OpenCVDriver")
         .def(pybind11::init<int>())
         .def("get_observation", &OpenCVDriver::get_observation);
 
 #ifdef Pylon_FOUND
     pybind11::class_<PylonDriver,
                      std::shared_ptr<PylonDriver>,
-                     SensorDriver<CameraObservation>>(m, "PylonDriver")
+                     SensorDriver<CameraObservation, CameraInfo>>(m,
+                                                                  "PylonDriver")
         .def(pybind11::init<const std::string&, bool>(),
              pybind11::arg("device_user_id"),
              pybind11::arg("downsample_images") = true)
@@ -45,6 +48,16 @@ PYBIND11_MODULE(py_camera_types, m)
         .def_readwrite("timestamp",
                        &CameraObservation::timestamp,
                        "Timestamp when the image was acquired.");
+
+    pybind11::class_<CameraInfo>(m, "CameraInfo")
+        .def(pybind11::init<>())
+        .def_readwrite("frame_rate_fps", &CameraInfo::frame_rate_fps)
+        .def_readwrite("image_width", &CameraInfo::image_width)
+        .def_readwrite("image_height", &CameraInfo::image_height)
+        .def_readwrite("camera_matrix", &CameraInfo::camera_matrix)
+        .def_readwrite("distortion_coefficients",
+                       &CameraInfo::distortion_coefficients)
+        .def_readwrite("tf_world_to_camera", &CameraInfo::tf_world_to_camera);
 
     pybind11::class_<PylonDriverSettings, std::shared_ptr<PylonDriverSettings>>(
         m, "PylonDriverSettings")

--- a/srcpy/py_camera_types.cpp
+++ b/srcpy/py_camera_types.cpp
@@ -5,6 +5,7 @@
  * @license BSD 3-clause
  */
 #include <pybind11/pybind11.h>
+#include <pybind11/stl/filesystem.h>
 #include <pybind11_opencv/cvbind.hpp>
 
 #include <trifinger_cameras/camera_observation.hpp>
@@ -38,6 +39,9 @@ PYBIND11_MODULE(py_camera_types, m)
                                                                   "PylonDriver")
         .def(pybind11::init<const std::string&, bool>(),
              pybind11::arg("device_user_id"),
+             pybind11::arg("downsample_images") = true)
+        .def(pybind11::init<const std::filesystem::path&, bool>(),
+             pybind11::arg("camera_calibration_file"),
              pybind11::arg("downsample_images") = true)
         .def("get_observation", &PylonDriver::get_observation);
 #endif


### PR DESCRIPTION
## Description

In https://github.com/open-dynamic-robot-initiative/robot_interfaces/pull/133, robot_interfaces adds an option to provide static sensor information.  Use this to provide information about frame rate and intrinsic/extrinsic camera parameters to the user.

This PR adds a `CameraInfo` struct which extends `CameraParameters` by also adding frame rate information.  This is used  as sensor info in the `PylonDriver`.  `TriCameraInfo`, used by `TriCameraDriver` and the `PyBulletTriCameraDriver`, simply holds an array with a `CameraInfo` instance for each camera.
Note that in this case the frame rate is stored for each camera separately (but all to the same value), which is maybe not super-nice but adding a more specific struct for TriCamera setup seemed a bit overkill to me.

No sensor info is provided for the OpenCV driver, which I think is not really used anywhere (it was just implemented for easy testing of the pipeline).

For testing this, I also made some adjustments to the demo scripts and added scripts to easily run a camera backend.


## Do not merge before

- https://github.com/open-dynamic-robot-initiative/robot_interfaces/pull/133
