### PR TITLE
fix: Export dependencies needed for pylon_driver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - pybind11 build error on Ubuntu 22.04
 - Connecting to camera without specifying DeviceUserID was not working.  It now opens
   the first camera in the list of connected cameras if no ID is specified.
+- Export dependencies needed when using the `pylon_driver` library in an other package.
 
 ### Changed
 - `pylon_list_cameras`:  Keep stdout clean if there are no cameras.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -335,5 +335,13 @@ endif()
 
 
 ament_export_targets(export_${PROJECT_NAME} HAS_LIBRARY_TARGET)
-ament_export_dependencies(yaml_utils sensor_msgs tomlplusplus fmt)
+ament_export_dependencies(
+    ament_index_cpp
+    fmt
+    robot_interfaces
+    sensor_msgs
+    serialization_utils
+    tomlplusplus
+    yaml_utils
+)
 ament_package(CONFIG_EXTRAS cmake/cfg_extras.cmake.in)


### PR DESCRIPTION
Add some packages in `ament_export_dependencies`, that were missing in order to enable other packages to use the pylon_driver library.
I also reordered the list alphabetically so it's easier to maintain.