### PR TITLE
Add tricamera_log_extract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Implement `get_sensor_info()` for Pylon and PyBullet drivers.  See `demo_camera` and
   `demo_tricamera` on how to use it.
 - Executable `record_tricamera_log` for recording camera data for testing, etc.
+- Executable `tricamera_log_extract` for extracting still images from a camera log file.
 
 ### Removed
 - Obsolete script `verify_calibration.py`

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -285,6 +285,7 @@ install_scripts(
     scripts/single_camera_backend.py
     scripts/tricamera_backend.py
     scripts/tricamera_log_converter.py
+    scripts/tricamera_log_extract.py
     scripts/tricamera_log_viewer.py
     scripts/tricamera_monitor_rate.py
     scripts/tricamera_test_connection.py

--- a/doc/executables.rst
+++ b/doc/executables.rst
@@ -160,3 +160,33 @@ example, be viewed using ``tricamera_log_viewer``.
 
 Note that the logger buffer is limited to 60 seconds by default.  If the buffer is full,
 the logger will stop recording.
+
+
+tricamera_log_extract
+=====================
+
+Extract the individual frames from a TriCamera log file.
+
+Basic usage:
+
+.. code-block:: sh
+
+   tricamera_log_extract <camera data file> <output directory>
+
+Images will be saved in the output directory using the following structure:
+
+::
+
+    output_directory
+    ├── 0001
+    │   ├── camera180.png
+    │   ├── camera300.png
+    │   └── camera60.png
+    ├── 0002
+    │   ├── camera180.png
+    │   ├── camera300.png
+    │   └── camera60.png
+    ...
+
+
+See ``--help`` for available options.

--- a/python/trifinger_cameras/tools/tricamera_log_extract.py
+++ b/python/trifinger_cameras/tools/tricamera_log_extract.py
@@ -1,0 +1,54 @@
+"""Extract images from a TriCamera log file."""
+
+import argparse
+import pathlib
+import sys
+import cv2
+
+from trifinger_cameras import utils
+
+
+def tricamera_log_extract(log_reader_class) -> None:  # noqa: ANN001
+    """Extract images from a TriCamera log file.
+
+    Args:
+        LogReader: LogReader class that can read the log file.  For log files recorded
+        with this package, use :class:`trifinger_cameras.tricamera.LogReader`.  By
+        passing the equivalent class of ``trifinger_object_tracking`` the same function
+        can be used to load log files that include object data.
+    """
+    argparser = argparse.ArgumentParser(description=__doc__)
+    argparser.add_argument(
+        "filename",
+        type=str,
+        help="""Path to the log file.""",
+    )
+    argparser.add_argument(
+        "output_dir",
+        type=str,
+        help="Directory to which images are stored.",
+    )
+    argparser.add_argument(
+        "--step",
+        "-s",
+        type=int,
+        metavar="n",
+        help="Extract only every n-th frame.",
+    )
+    args = argparser.parse_args()
+
+    out_dir = pathlib.Path(args.output_dir)
+
+    if not out_dir.is_dir():
+        print("{} does not exist or is not a directory".format(out_dir))
+        sys.exit(1)
+
+    log_reader = log_reader_class(args.filename)
+
+    for i, observation in enumerate(log_reader.data[:: args.step]):
+        observation_dir = out_dir / ("%04d" % (i + 1))
+        observation_dir.mkdir()
+        for camera_idx, name in enumerate(["camera60", "camera180", "camera300"]):
+            image = utils.convert_image(observation.cameras[camera_idx].image)
+            img_path = observation_dir / "{}.png".format(name)
+            cv2.imwrite(str(img_path), image)

--- a/scripts/tricamera_log_extract.py
+++ b/scripts/tricamera_log_extract.py
@@ -1,0 +1,8 @@
+#!/usr/bin/env python3
+"""Extract images from a TriCameraObservations log file."""
+
+import trifinger_cameras
+from trifinger_cameras.tools.tricamera_log_extract import tricamera_log_extract
+
+if __name__ == "__main__":
+    tricamera_log_extract(trifinger_cameras.tricamera.LogReader)


### PR DESCRIPTION


[//]: # "Thanks for your contribution.  To make life of the reviewers easier,"
[//]: # "please give this pull request a meaningful title and provide the"
[//]: # "requested information below."

## Description

Simple script to still images from a camera observation log.  This already exists in trifinger_object_tracking but there wasn't a version for logs without object data.

To avoid code duplication, implement it as a function that takes the log reader as input.  With this, the corresponding script in trifinger_object_tracking can simply import that function and pass the proper LogReader.


## How I Tested

Tested by manually running it.

