### PR TITLE
Some updates in camera calibration script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 
 ### Changed
 - `pylon_list_cameras`:  Keep stdout clean if there are no cameras.
+- Camera calibration YAML files are now compatible with OpenCVs YAML parser.
 
 
 ## [1.0.0] - 2022-06-28

--- a/scripts/calibrate_cameras.py
+++ b/scripts/calibrate_cameras.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """Script for generating the calibration data for the cameras and verifying the
- output.
+output.
 """
 
 from trifinger_cameras.charuco_board_handler import CharucoBoardHandler

--- a/scripts/calibrate_trifingerpro_cameras.py
+++ b/scripts/calibrate_trifingerpro_cameras.py
@@ -13,6 +13,7 @@ import os
 import cv2
 import numpy as np
 import yaml
+from ruamel.yaml import YAML
 
 from trifinger_cameras import utils
 from trifinger_cameras.charuco_board_handler import CharucoBoardHandler
@@ -301,32 +302,41 @@ def save_parameter_file(params: CameraParameters, filename: str) -> None:
     calibration_data["camera_matrix"] = {
         "rows": 3,
         "cols": 3,
+        "dt": "d",
         "data": params.camera_matrix.flatten().tolist(),
     }
 
     calibration_data["distortion_coefficients"] = {
         "rows": 1,
         "cols": 5,
+        "dt": "d",
         "data": params.dist_coeffs.flatten().tolist(),
     }
 
     calibration_data["tf_world_to_camera"] = {
         "rows": 4,
         "cols": 4,
+        "dt": "d",
         "data": params.tf_world_to_camera.flatten().tolist(),
     }
 
     calibration_data["tf_world_to_camera_std"] = {
         "rows": 4,
         "cols": 4,
+        "dt": "d",
         "data": params.tf_world_to_camera_std.flatten().tolist(),
     }
 
+    ryaml = YAML()
+    ryaml.version = (1, 1)  # type: ignore[assignment]
+    ryaml.explicit_start = True  # type: ignore[assignment]
+    # indent lists in opencv-compatible way
+    ryaml.indent(offset=2)
+
     with open(filename, "w") as outfile:
-        yaml.dump(
+        ryaml.dump(
             calibration_data,
             outfile,
-            default_flow_style=False,
         )
 
 

--- a/scripts/calibrate_trifingerpro_cameras.py
+++ b/scripts/calibrate_trifingerpro_cameras.py
@@ -12,7 +12,6 @@ import os
 
 import cv2
 import numpy as np
-import yaml
 from ruamel.yaml import YAML
 
 from trifinger_cameras import utils
@@ -397,7 +396,7 @@ def main() -> None:
 
     if args.intrinsic_file:
         with open(args.intrinsic_file) as file:
-            calibration_data = yaml.safe_load(file)
+            calibration_data = YAML(typ="safe").load(file)
 
         def config_matrix(data: dict) -> np.ndarray:
             return np.array(data["data"]).reshape(data["rows"], data["cols"])

--- a/scripts/calibrate_trifingerpro_cameras.py
+++ b/scripts/calibrate_trifingerpro_cameras.py
@@ -258,8 +258,8 @@ def calibrate_mean_extrinsic_parameters(
             for p1, p2 in point_pairs:
                 cv2.line(
                     img,
-                    tuple(imgpoints[p1, 0]),
-                    tuple(imgpoints[p2, 0]),
+                    tuple(imgpoints[p1, 0].astype(int)),
+                    tuple(imgpoints[p2, 0].astype(int)),
                     [200, 200, 0],
                     thickness=2,
                 )

--- a/scripts/calibrate_trifingerpro_cameras.py
+++ b/scripts/calibrate_trifingerpro_cameras.py
@@ -52,7 +52,7 @@ def get_image_files(data_dir: str, camera_name: str) -> list[str]:
 
 
 def calibrate_intrinsic_parameters(
-    image_files: list[str], calibration_results_file: str, visualize: bool = False
+    image_files: list[str], visualize: bool = False
 ) -> tuple[np.ndarray, np.ndarray]:
     """Calibrate intrinsic parameters of the camera given different images
     taken for the Charuco board from different views, the resulting parameters
@@ -60,8 +60,6 @@ def calibrate_intrinsic_parameters(
 
     Args:
         image_files:  List of calibration image files.
-        calibration_results_file:  filepath that will be used to write the calibration
-            results in.
         visualize:  If true, show visualization of the board detection.
     """
     handler = CharucoBoardHandler(
@@ -71,23 +69,7 @@ def calibrate_intrinsic_parameters(
     camera_matrix, dist_coeffs, error = handler.calibrate(
         image_files, visualize=visualize
     )
-    camera_info: dict = {}
-    camera_info["camera_matrix"] = {}
-    camera_info["camera_matrix"]["rows"] = 3
-    camera_info["camera_matrix"]["cols"] = 3
-    camera_info["camera_matrix"]["data"] = camera_matrix.flatten().tolist()
-    camera_info["distortion_coefficients"] = {}
-    camera_info["distortion_coefficients"]["rows"] = 1
-    camera_info["distortion_coefficients"]["cols"] = 5
-    camera_info["distortion_coefficients"]["data"] = dist_coeffs.flatten().tolist()
 
-    # TODO: do we need to save here? won't this be overwritten later anyway?
-    with open(calibration_results_file, "w") as outfile:
-        yaml.dump(
-            camera_info,
-            outfile,
-            default_flow_style=False,
-        )
     return camera_matrix, dist_coeffs
 
 
@@ -95,7 +77,7 @@ def calibrate_mean_extrinsic_parameters(
     camera_matrix: np.ndarray,
     dist_coeffs: np.ndarray,
     image_files: list[str],
-    impose_cube: bool=True,
+    impose_cube: bool = True,
 ) -> CameraParameters:
     """Calibrate extrinsic parameters of the camera.
 
@@ -414,7 +396,7 @@ def main() -> None:
         dist_coeffs = config_matrix(calibration_data["distortion_coefficients"])
     else:
         camera_matrix, dist_coeffs = calibrate_intrinsic_parameters(
-            image_files, output_file_full, args.visualize
+            image_files, args.visualize
         )
 
     camera_params = calibrate_mean_extrinsic_parameters(

--- a/scripts/overlay_camera_stream.py
+++ b/scripts/overlay_camera_stream.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
-"""
-"""
+"""Overlay an image on top of the camera stream."""
 import argparse
 import cv2
 


### PR DESCRIPTION
## Description

Several small changes in the script for TriFinger camera calibration:

- Make YAML files with camera parameters compatible with OpenCVs YAML parser.  Switch from pyyaml to ruamel.yaml for this.
- Fix crash in visualization code (cv::line needs integer coordinates, not sure why this wasn't an issue before).
- Fix several linter errors.