### PR TITLE
fix: Points for drawing lines must be int.

### DIFF
--- a/scripts/calibrate_trifingerpro_cameras.py
+++ b/scripts/calibrate_trifingerpro_cameras.py
@@ -258,8 +258,8 @@ def calibrate_mean_extrinsic_parameters(
             for p1, p2 in point_pairs:
                 cv2.line(
                     img,
-                    tuple(imgpoints[p1, 0]),
-                    tuple(imgpoints[p2, 0]),
+                    tuple(imgpoints[p1, 0].astype(int)),
+                    tuple(imgpoints[p2, 0].astype(int)),
                     [200, 200, 0],
                     thickness=2,
                 )


### PR DESCRIPTION
imgpoints are float, which `cv2.line` doesn't seem to like.  I don't know why this wasn't a problem in the past but it was failing for me now (maybe different version?).
Casting points to int for drawing the line fixes the issue.