### PR TITLE
Add script to convert TriCamera log files to HDF5 and extend Viewer to read them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,12 @@
   `demo_tricamera` on how to use it.
 - Executable `record_tricamera_log` for recording camera data for testing, etc.
 - Executable `tricamera_log_extract` for extracting still images from a camera log file.
+- Executable `tricamera_log_to_hdf5` to convert recorded log files from the native
+  format to HDF5 (which can easily be read without needing to depend on TriFinger
+  packages).  Extend the `tricamera_log_viewer` to be able to read those HDF5 files for
+  viewing.
+- Add clipping indicator to `tricamera_log_viewer` (meant as an aid to find good
+  exposure settings for the cameras).
 
 ### Removed
 - Obsolete script `verify_calibration.py`

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -286,6 +286,7 @@ install_scripts(
     scripts/tricamera_backend.py
     scripts/tricamera_log_converter.py
     scripts/tricamera_log_extract.py
+    scripts/tricamera_log_to_hdf5.py
     scripts/tricamera_log_viewer.py
     scripts/tricamera_monitor_rate.py
     scripts/tricamera_test_connection.py

--- a/python/trifinger_cameras/__init__.py
+++ b/python/trifinger_cameras/__init__.py
@@ -2,3 +2,10 @@
 # F401 = unused import, F403 = complaint about `import *`.
 from . import py_camera_types as camera  # noqa: F401
 from . import py_tricamera_types as tricamera  # noqa: F401
+
+
+#: Names of the TriFinger cameras in the order in which they are usually handled.
+CAMERA_NAMES = ("camera60", "camera180", "camera300")
+
+#: Magic byte used to identify TriCamera logs (currently only used in HDF5 files).
+TRICAMERA_LOG_MAGIC = 0x3CDA7A00

--- a/python/trifinger_cameras/camera_calibration_file.py
+++ b/python/trifinger_cameras/camera_calibration_file.py
@@ -1,12 +1,14 @@
+from typing import Any
+
 import yaml
 import numpy as np
 
 
-def config_to_array(data):
+def config_to_array(data: dict) -> np.ndarray:
     """Convert a dictionary with keys "data", "rows" and "cols" to an array.
 
     Args:
-        data (dict):  Dictionary containing the following keys:
+        data:  Dictionary containing the following keys:
             - "data": a flat list with the array data.
             - "rows": The number of rows in the array.
             - "cols": The number of columns in the array.
@@ -20,24 +22,34 @@ def config_to_array(data):
 class CameraCalibrationFile:
     """Simplifies access to the data in a camera calibration file."""
 
-    def __init__(self, filename):
+    def __init__(self, filename: str) -> None:
         """Load the file.
 
         Args:
-            filename (str):  Path to the calibration YAML file.
+            filename:  Path to the calibration YAML file.
         """
         self.filename = filename
 
         with open(filename) as file:
             self.data = yaml.safe_load(file)
 
-    def __getitem__(self, name):
+    def __getitem__(self, name: str) -> Any:
+        """Get the specified field from the calibration data.
+
+        Array data is converted to numpy arrays, other fields are returned as is.
+        """
+        raw_data = self.data[name]
+        if isinstance(raw_data, dict):
+            return self.get_array(name)
+        return raw_data
+
+    def get_array(self, name: str) -> np.ndarray:
         """Get the specified array from the calibration data.
 
         Args:
-            name (str):  Name of the array.
+            name:  Name of the array (e.g. "camera_matrix").
 
         Returns:
-            (numpy.array):  The array with the specified name.
+            The array with the specified name.
         """
         return config_to_array(self.data[name])

--- a/python/trifinger_cameras/hdf5.py
+++ b/python/trifinger_cameras/hdf5.py
@@ -1,0 +1,27 @@
+"""Utilities for working with HDF5 camera log files."""
+
+from collections.abc import Container
+
+import h5py
+
+from . import TRICAMERA_LOG_MAGIC
+
+
+def verify_tricamera_hdf5(h5file: h5py.File, supported_formats: Container[int]) -> None:
+    """Verify that the HDF5 file is a valid TriCamera log file of a supported version.
+
+    Args:
+        h5file: Opened HDF5 file.
+        supported_formats: Supported file formats.
+
+    Raises:
+        ValueError: If the file is not a valid TriCamera log file (based on magic byte)
+            or the format version is not supported.
+    """
+    if h5file.attrs.get("magic") != TRICAMERA_LOG_MAGIC:
+        msg = "Input file doesn't seem to be a TriCamera log file (bad magic byte)."
+        raise ValueError(msg)
+
+    if h5file.attrs["format_version"] not in supported_formats:
+        msg = f"Unsupported file format version {h5file.attrs['format_version']}"
+        raise ValueError(msg)

--- a/scripts/tricamera_log_to_hdf5.py
+++ b/scripts/tricamera_log_to_hdf5.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Convert TriCameraObservation log file to hdf5."""
+
+import argparse
+import pathlib
+import sys
+
+import cv2
+import h5py
+import numpy as np
+
+import trifinger_cameras
+from trifinger_cameras import utils
+
+CAMERA_NAMES = ("camera60", "camera180", "camera300")
+
+
+def main() -> int:
+    """Main entry point of the script."""
+    argparser = argparse.ArgumentParser(description=__doc__)
+    argparser.add_argument(
+        "logfile",
+        type=pathlib.Path,
+        help="Path to the log file.",
+    )
+    argparser.add_argument(
+        "outfile",
+        type=pathlib.Path,
+        help="Path to the output hdf5 file.",
+    )
+    args = argparser.parse_args()
+
+    if not args.logfile.is_file():
+        print("Log file does not exist.", file=sys.stderr)
+        return 1
+
+    if args.outfile.exists():
+        print("Output file already exists.  Exiting.", file=sys.stderr)
+        return 1
+
+    log_reader = trifinger_cameras.tricamera.LogReader(str(args.logfile))
+
+    n_frames = len(log_reader.data)
+    assert n_frames > 0, "No frames found in log file."
+
+    img_shape = log_reader.data[0].cameras[0].image.shape
+
+    with h5py.File(args.outfile, "w") as h5:
+        # create datasets for images and timestamps
+        h5.create_dataset("camera_names", data=[name.encode() for name in CAMERA_NAMES])
+        h5.attrs["magic"] = 0x3CDA7A00
+        h5.attrs["format_version"] = 1
+        h5.attrs["num_cameras"] = len(CAMERA_NAMES)
+        h5.attrs["image_width"] = img_shape[1]
+        h5.attrs["image_height"] = img_shape[0]
+
+        h5.create_dataset(
+            "images",
+            shape=(n_frames, len(CAMERA_NAMES), img_shape[0], img_shape[1]),
+            dtype=np.uint8,
+            chunks=(1, len(CAMERA_NAMES), img_shape[0], img_shape[1]),
+            compression="gzip",
+            shuffle=True,
+        )
+
+        h5.create_dataset(
+            "timestamps",
+            shape=(n_frames, len(CAMERA_NAMES)),
+            dtype=np.double,
+        )
+
+        for i_obs, observation in enumerate(log_reader.data):
+            cameras = observation.cameras
+            h5["images"][i_obs] = [camera.image for camera in cameras]
+            h5["timestamps"][i_obs] = [camera.timestamp for camera in cameras]
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tricamera_log_viewer.py
+++ b/scripts/tricamera_log_viewer.py
@@ -70,6 +70,17 @@ def read_hdf5(filename: pathlib.Path) -> Generator[tuple[int, np.ndarray]]:
             yield interval, img
 
 
+def indicate_clipping(image: np.ndarray) -> np.ndarray:
+    """Set clipped pixels to pure red."""
+    # image = image.copy()
+
+    # set clipped pixels to pure red
+    image[image[:, :, 0] == 255] = [0, 0, 255]
+    image[image[:, :, 1] == 255] = [0, 0, 255]
+    image[image[:, :, 2] == 255] = [0, 0, 255]
+    return image
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
@@ -80,6 +91,11 @@ def main() -> None:
     parser.add_argument("--speed", type=float, default=1.0, help="Playback speed.")
     parser.add_argument(
         "--skip", type=int, default=0, metavar="n", help="Skip the first n frames."
+    )
+    parser.add_argument(
+        "--indicate-clipping",
+        action="store_true",
+        help="Visualize clipped pixels by setting them to pure red.",
     )
     args = parser.parse_args()
 
@@ -94,6 +110,10 @@ def main() -> None:
             frame_number += 1
             if frame_number <= args.skip:
                 continue
+
+            if args.indicate_clipping:
+                image = indicate_clipping(image)
+
             cv2.putText(
                 image,
                 f"Frame {frame_number}",

--- a/scripts/tricamera_log_viewer.py
+++ b/scripts/tricamera_log_viewer.py
@@ -1,24 +1,25 @@
 #!/usr/bin/env python3
-"""
-Play back TriCameraObservations from a log file.
-"""
+"""Play back TriCameraObservations from a log file."""
+
+from __future__ import annotations
+
 import argparse
+import pathlib
+import time
+from typing import Generator
+
 import cv2
+import numpy as np
 
 import trifinger_cameras
 from trifinger_cameras import utils
 
 
-def main():
-    argparser = argparse.ArgumentParser(description=__doc__)
-    argparser.add_argument(
-        "filename",
-        type=str,
-        help="""Path to the log file.""",
-    )
-    args = argparser.parse_args()
-
-    log_reader = trifinger_cameras.tricamera.LogReader(args.filename)
+def read_sensor_log(filename: pathlib.Path) -> Generator[tuple[int, np.ndarray]]:
+    t_start = time.monotonic()
+    log_reader = trifinger_cameras.tricamera.LogReader(str(filename))
+    t_end = time.monotonic()
+    print("Time for reading log file: {:.3f} s".format(t_end - t_start))
 
     # determine rate based on time stamps
     start_time = log_reader.data[0].cameras[0].timestamp
@@ -34,16 +35,82 @@ def main():
     )
 
     for observation in log_reader.data:
-        window_60 = "Image Stream camera60"
-        window_180 = "Image Stream camera180"
-        window_300 = "Image Stream camera300"
-        cv2.imshow(window_60, utils.convert_image(observation.cameras[0].image))
-        cv2.imshow(window_180, utils.convert_image(observation.cameras[1].image))
-        cv2.imshow(window_300, utils.convert_image(observation.cameras[2].image))
+        img = np.hstack(
+            [
+                utils.convert_image(observation.cameras[0].image),
+                utils.convert_image(observation.cameras[1].image),
+                utils.convert_image(observation.cameras[2].image),
+            ]
+        )
+        yield interval, img
 
-        # stop if either "q" or ESC is pressed
-        if cv2.waitKey(interval) in [ord("q"), 27]:  # 27 = ESC
-            break
+
+def read_hdf5(filename: pathlib.Path) -> Generator[tuple[int, np.ndarray]]:
+    import h5py
+
+    with h5py.File(filename, "r") as h5:
+        if h5.attrs.get("magic") != 0x3CDA7A00:
+            msg = "Input file doesn't seem to be a TriCamera log file (bad magic byte)."
+            raise ValueError(msg)
+        if h5.attrs["format_version"] != 1:
+            msg = f"Unsupported file format version {h5.attrs['format_version']}"
+            raise ValueError(msg)
+
+        timestamps = h5["timestamps"]
+        # determine rate based on first and last time stamp
+        interval = int((timestamps[-1][0] - timestamps[0][0]) / len(timestamps) * 1000)
+        print(
+            "Loaded {} frames at an average interval of {} ms ({:.1f} fps)".format(
+                len(h5["images"]), interval, 1000 / interval
+            )
+        )
+
+        for images in h5["images"]:
+            img = np.hstack([utils.convert_image(img) for img in images])
+            yield interval, img
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "filename",
+        type=pathlib.Path,
+        help="""Path to the log file.""",
+    )
+    parser.add_argument("--speed", type=float, default=1.0, help="Playback speed.")
+    parser.add_argument(
+        "--skip", type=int, default=0, metavar="n", help="Skip the first n frames."
+    )
+    args = parser.parse_args()
+
+    window_title = "camera 60 | camera 180 | camera300"
+    read_func = (
+        read_hdf5 if args.filename.suffix in (".h5", ".hdf5") else read_sensor_log
+    )
+
+    try:
+        frame_number = 0
+        for interval, image in read_func(args.filename):
+            frame_number += 1
+            if frame_number <= args.skip:
+                continue
+            cv2.putText(
+                image,
+                f"Frame {frame_number}",
+                (10, image.shape[0] - 10),
+                cv2.FONT_HERSHEY_SIMPLEX,
+                1,
+                (255, 255, 255),
+            )
+
+            cv2.imshow(window_title, image)
+
+            scaled_interval = int(interval / args.speed)
+            # stop if either "q" or ESC is pressed
+            if cv2.waitKey(max(scaled_interval, 1)) in [ord("q"), 27]:  # 27 = ESC
+                break
+    except Exception as e:
+        print("Error:", e)
 
 
 if __name__ == "__main__":

--- a/scripts/tricamera_log_viewer.py
+++ b/scripts/tricamera_log_viewer.py
@@ -49,10 +49,10 @@ def read_hdf5(filename: pathlib.Path) -> Generator[tuple[int, np.ndarray]]:
     import h5py
 
     with h5py.File(filename, "r") as h5:
-        if h5.attrs.get("magic") != 0x3CDA7A00:
+        if h5.attrs.get("magic") != trifinger_cameras.TRICAMERA_LOG_MAGIC:
             msg = "Input file doesn't seem to be a TriCamera log file (bad magic byte)."
             raise ValueError(msg)
-        if h5.attrs["format_version"] != 1:
+        if h5.attrs["format_version"] not in (1, 2):
             msg = f"Unsupported file format version {h5.attrs['format_version']}"
             raise ValueError(msg)
 
@@ -83,7 +83,7 @@ def main() -> None:
     )
     args = parser.parse_args()
 
-    window_title = "camera 60 | camera 180 | camera300"
+    window_title = " | ".join(trifinger_cameras.CAMERA_NAMES)
     read_func = (
         read_hdf5 if args.filename.suffix in (".h5", ".hdf5") else read_sensor_log
     )

--- a/scripts/tricamera_log_viewer.py
+++ b/scripts/tricamera_log_viewer.py
@@ -12,7 +12,7 @@ import cv2
 import numpy as np
 
 import trifinger_cameras
-from trifinger_cameras import utils
+from trifinger_cameras import hdf5, utils
 
 
 def read_sensor_log(filename: pathlib.Path) -> Generator[tuple[int, np.ndarray]]:
@@ -49,12 +49,7 @@ def read_hdf5(filename: pathlib.Path) -> Generator[tuple[int, np.ndarray]]:
     import h5py
 
     with h5py.File(filename, "r") as h5:
-        if h5.attrs.get("magic") != trifinger_cameras.TRICAMERA_LOG_MAGIC:
-            msg = "Input file doesn't seem to be a TriCamera log file (bad magic byte)."
-            raise ValueError(msg)
-        if h5.attrs["format_version"] not in (1, 2):
-            msg = f"Unsupported file format version {h5.attrs['format_version']}"
-            raise ValueError(msg)
+        hdf5.verify_tricamera_hdf5(h5, supported_formats=(1, 2))
 
         timestamps = h5["timestamps"]
         # determine rate based on first and last time stamp

--- a/srcpy/py_camera_types.cpp
+++ b/srcpy/py_camera_types.cpp
@@ -54,6 +54,16 @@ PYBIND11_MODULE(py_camera_types, m)
                        &CameraObservation::timestamp,
                        "Timestamp when the image was acquired.");
 
+    pybind11::class_<CameraParameters>(m, "CameraParameters")
+        .def(pybind11::init<>())
+        .def_readwrite("image_width", &CameraInfo::image_width)
+        .def_readwrite("image_height", &CameraInfo::image_height)
+        .def_readwrite("camera_matrix", &CameraParameters::camera_matrix)
+        .def_readwrite("distortion_coefficients",
+                       &CameraParameters::distortion_coefficients)
+        .def_readwrite("tf_world_to_camera",
+                       &CameraParameters::tf_world_to_camera);
+
     pybind11::class_<CameraInfo>(m, "CameraInfo")
         .def(pybind11::init<>())
         .def_readwrite("frame_rate_fps", &CameraInfo::frame_rate_fps)


### PR DESCRIPTION
[//]: # "Thanks for your contribution.  To make life of the reviewers easier,"
[//]: # "please give this pull request a meaningful title and provide the"
[//]: # "requested information below."

## Description

Add executable `tricamera_log_to_hdf5` to convert recorded log files from the native format to HDF5 (which are more portable as they can easily be read without needing to depend on TriFinger packages).
Extend the `tricamera_log_viewer` to be able to read those HDF5 files for viewing.

The HDF5 files have about the same size as the native logs.  Reading is even faster and they allow to iterate through the data without needing to load everything into RAM at once (which is necessary with the native format).  Therefore, I'd actually like to eventually replace the native format completely (i.e. directly log to HDF5), but this would require sensor-specific implementation of the logger class, so would require some redesign of robot_interfaces.