### PR TITLE
Use pytest instead of nose

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -305,7 +305,7 @@ install(
 # Tests
 if (BUILD_TESTING)
     find_package(ament_cmake_gmock REQUIRED)
-    find_package(ament_cmake_nose REQUIRED)
+    find_package(ament_cmake_pytest REQUIRED)
 
     # install files that are used by the tests
     install(FILES tests/camera_calib.yml
@@ -330,8 +330,8 @@ if (BUILD_TESTING)
         camera_observations
     )
 
-    ament_add_nose_test(test_utils tests/test_utils.py)
-    ament_add_nose_test(test_camera_calibration_file
+    ament_add_pytest_test(test_utils tests/test_utils.py)
+    ament_add_pytest_test(test_camera_calibration_file
         tests/test_camera_calibration_file.py)
 endif()
 

--- a/package.xml
+++ b/package.xml
@@ -33,7 +33,7 @@
     <exec_depend>python-opencv</exec_depend>
 
     <test_depend>ament_cmake_gmock</test_depend>
-    <test_depend>ament_cmake_nose</test_depend>
+    <test_depend>ament_cmake_pytest</test_depend>
     <test_depend>ament_index_python</test_depend>
 
     <export>


### PR DESCRIPTION
The ament_cmake_nose package apparently doesn't exist anymore in ROS Jazzy.  We anyway write new tests for pytest, so let's simply switch to that.
There should be no need to do any changes on the actual test as pytest can run them as well.

[//]: # "Thanks for your contribution.  To make life of the reviewers easier,"
[//]: # "please give this pull request a meaningful title and provide the"
[//]: # "requested information below."
