### PR TITLE
Initialize last_update_time_ in first call of get_observation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,8 @@
 - Connecting to camera without specifying DeviceUserID was not working.  It now opens
   the first camera in the list of connected cameras if no ID is specified.
 - Export dependencies needed when using the `pylon_driver` library in an other package.
+- Fixed timing issue in `TriCameraDriver`, which resulted in the first iterations to
+  ignore the configured camera rate and instead to run at full speed.
 
 ### Changed
 - `pylon_list_cameras`:  Keep stdout clean if there are no cameras.


### PR DESCRIPTION

## Description
Just initializing it in the constructor doesn't work well, as it can already be quite out-dated at the first call of get_observation().  This results in the first calls to always get the observation immediately without sleep, thus ignoring the configured rate.

With the change of this commit, the first call to get_observation() should return immediately and from then on adhere to `rate`, no matter how much time has passed between driver construction and start of the backend loop.

It is still also initialized in the constructors, which is not really needed anymore but I left it as a safe guard just in case (if something goes wrong, it's better to be initialized with a slightly outdated time than to be not initialized at all).

## How I Tested

Recorded some data and looked at the timestamps of the observations.