### PR TITLE
Remove the option to downsample images in the driver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 
 ### Removed
 - Obsolete script `verify_calibration.py`
+- Option to downsample images inside PylonDriver (see also "Changed" section).
 
 ### Fixed
 - pybind11 build error on Ubuntu 22.04
@@ -41,6 +42,9 @@
   ignore the configured camera rate and instead to run at full speed.
 
 ### Changed
+- BREAKING: The images provided by PylonDriver are not downsampled anymore.  They are
+  now always the full resolution of 540x540 px.  The corresponding argument of the
+  driver class is kept for now but will throw an exception when set to `true`.
 - `pylon_list_cameras`:  Keep stdout clean if there are no cameras.
 - Camera calibration YAML files are now compatible with OpenCVs YAML parser.
 

--- a/include/trifinger_cameras/camera_observation.hpp
+++ b/include/trifinger_cameras/camera_observation.hpp
@@ -19,8 +19,10 @@ namespace trifinger_cameras
  */
 struct CameraObservation
 {
-    static constexpr size_t width = 270;
-    static constexpr size_t height = 270;
+    // image size needs to be hard-coded here for shared memory time series to
+    // work correctly (serialized size must be fixed).
+    static constexpr size_t width = 540;
+    static constexpr size_t height = 540;
 
     cv::Mat image;
     double timestamp;

--- a/include/trifinger_cameras/pylon_driver.hpp
+++ b/include/trifinger_cameras/pylon_driver.hpp
@@ -58,12 +58,11 @@ public:
      *
      * @param device_user_id "DeviceUserID" of the camera.  Pass empty string to
      * connect to first camera found (useful if only one camera is connected).
-     * @param downsample_images If set to true (default), images are downsampled
-     *     to half their original size.
+     * @param downsample_images Not supported anymore.  Must be to ``false``.
      * @param settings Settings for the camera.
      */
     PylonDriver(const std::string& device_user_id,
-                bool downsample_images = true,
+                bool downsample_images = false,
                 Settings settings = Settings());
 
     /**
@@ -75,26 +74,14 @@ public:
      * get_sensor_info.
      *
      * @param camera_calibration_file Path to the camera calibration file.
-     * @param downsample_images If set to true (default), images are downsampled
-     *     to half their original size.
+     * @param downsample_images Not supported anymore.  Must be to ``false``.
      * @param settings Settings for the camera.
      */
     PylonDriver(const std::filesystem::path& camera_calibration_file,
-                bool downsample_images = true,
+                bool downsample_images = false,
                 Settings settings = Settings());
 
     ~PylonDriver();
-
-    /**
-     * @brief Downsample raw Bayer pattern by factor 2.
-     *
-     * Downsample a raw image by factor two, preserving the Bayer pattern.
-     *
-     * @param image Original image.
-     *
-     * @return Downsampled image.
-     */
-    static cv::Mat downsample_raw_image(const cv::Mat& image);
 
     /**
      * @brief Get the camera parameters (image size and calibration
@@ -117,15 +104,13 @@ private:
     std::shared_ptr<const PylonDriverSettings> settings_;
     trifinger_cameras::CameraInfo camera_info_ = {};
     std::string device_user_id_;
-    const bool downsample_images_;
     Pylon::PylonAutoInitTerm auto_init_term_;
     Pylon::CInstantCamera camera_;
     Pylon::CImageFormatConverter format_converter_;
 
     /**
      * @brief Base constructor to be called by public constructors.
-     * @param downsample_images If set to true (default), images are downsampled
-     *     to half their original size.
+     * @param downsample_images Not supported anymore.  Must be to ``false``.
      * @param settings Settings for the camera.
      */
     PylonDriver(bool downsample_images, Settings settings);

--- a/include/trifinger_cameras/tricamera_driver.hpp
+++ b/include/trifinger_cameras/tricamera_driver.hpp
@@ -36,28 +36,26 @@ public:
      * @param device_id_1 device user id of first camera
      * @param device_id_2 likewise, the 2nd's
      * @param device_id_3 and the 3rd's
-     * @param downsample_images If set to true (default), images are
-     *     downsampled to half their original size.
+     * @param downsample_images Not supported anymore.  Must be to ``false``.
      * @param settings Settings for the cameras.
      */
     TriCameraDriver(const std::string& device_id_1,
                     const std::string& device_id_2,
                     const std::string& device_id_3,
-                    bool downsample_images = true,
+                    bool downsample_images = false,
                     Settings settings = Settings());
 
     /**
      * @param camera_calibration_file_1 Calibration file of first camera
      * @param camera_calibration_file_2 likewise, the 2nd's
      * @param camera_calibration_file_3 and the 3rd's
-     * @param downsample_images If set to true (default), images are
-     *     downsampled to half their original size.
+     * @param downsample_images Not supported anymore.  Must be to ``false``.
      * @param settings Settings for the cameras.
      */
     TriCameraDriver(const std::filesystem::path& camera_calibration_file_1,
                     const std::filesystem::path& camera_calibration_file_2,
                     const std::filesystem::path& camera_calibration_file_3,
-                    bool downsample_images = true,
+                    bool downsample_images = false,
                     Settings settings = Settings());
 
     /**

--- a/scripts/overlay_camera_stream.py
+++ b/scripts/overlay_camera_stream.py
@@ -29,9 +29,7 @@ def main():
     overlay_image[:, :, 1] = 0
 
     camera_data = trifinger_cameras.camera.SingleProcessData()
-    camera_driver = trifinger_cameras.camera.PylonDriver(
-        args.camera_id, downsample_images=False
-    )
+    camera_driver = trifinger_cameras.camera.PylonDriver(args.camera_id)
     camera_backend = trifinger_cameras.camera.Backend(  # noqa
         camera_driver, camera_data
     )

--- a/scripts/record_image_dataset.py
+++ b/scripts/record_image_dataset.py
@@ -99,11 +99,6 @@ def main():
             For the "tri" driver, this value is ignored.
         """,
     )
-    argparser.add_argument(
-        "--downsample",
-        action="store_true",
-        help="""Downsample images by factor 2.  Only for Pylon cameras.""",
-    )
     args = argparser.parse_args()
 
     if args.driver != "tri" and args.camera_id is None:
@@ -112,15 +107,11 @@ def main():
 
     if args.driver == "tri":
         camera_names = ["camera60", "camera180", "camera300"]
-        camera_driver = trifinger_cameras.tricamera.TriCameraDriver(
-            *camera_names, args.downsample
-        )
+        camera_driver = trifinger_cameras.tricamera.TriCameraDriver(*camera_names)
         camera_module = trifinger_cameras.tricamera
         image_saver = TriImageSaver(args.outdir, camera_names)
     elif args.driver == "pylon":
-        camera_driver = trifinger_cameras.camera.PylonDriver(
-            args.camera_id, args.downsample
-        )
+        camera_driver = trifinger_cameras.camera.PylonDriver(args.camera_id)
         camera_module = trifinger_cameras.camera
         image_saver = SingleImageSaver(args.outdir, args.camera_id)
     elif args.driver == "opencv":

--- a/scripts/record_tricamera_log.py
+++ b/scripts/record_tricamera_log.py
@@ -26,11 +26,6 @@ def main() -> int:
         help="Buffer size of the logger in seconds. Default: %(default)s",
     )
     parser.add_argument(
-        "--no-downsample",
-        action="store_true",
-        help="Disable downsampling in the camera driver",
-    )
-    parser.add_argument(
         "--force", "-f", action="store_true", help="Overwrite existing files."
     )
     parser.add_argument(
@@ -59,11 +54,8 @@ def main() -> int:
     if args.multi_process:
         camera_data = trifinger_cameras.tricamera.MultiProcessData("tricamera", False)
     else:
-        downsample = not args.no_downsample
         camera_data = trifinger_cameras.tricamera.SingleProcessData()
-        camera_driver = trifinger_cameras.tricamera.TriCameraDriver(
-            *camera_names, downsample
-        )
+        camera_driver = trifinger_cameras.tricamera.TriCameraDriver(*camera_names)
         camera_backend = trifinger_cameras.tricamera.Backend(camera_driver, camera_data)
 
     camera_frontend = trifinger_cameras.tricamera.Frontend(camera_data)

--- a/src/pybullet_tricamera_driver.cpp
+++ b/src/pybullet_tricamera_driver.cpp
@@ -68,7 +68,7 @@ PyBulletTriCameraDriver::PyBulletTriCameraDriver(
         // cameras_ =
         // mod_camera.attr("create_trifinger_camera_array_from_config")(
         //   pathlib.attr("Path")("/etc/trifingerpro"),
-        //   "camera{id}_cropped_and_downsampled.yml");
+        //   "camera{id}_cropped.yml");
 
         // fill the sensor_info_ structure for all three cameras.
         for (size_t i = 0; i < 3; i++)

--- a/srcpy/py_camera_types.cpp
+++ b/srcpy/py_camera_types.cpp
@@ -39,10 +39,10 @@ PYBIND11_MODULE(py_camera_types, m)
                                                                   "PylonDriver")
         .def(pybind11::init<const std::string&, bool>(),
              pybind11::arg("device_user_id"),
-             pybind11::arg("downsample_images") = true)
+             pybind11::arg("downsample_images") = false)
         .def(pybind11::init<const std::filesystem::path&, bool>(),
              pybind11::arg("camera_calibration_file"),
-             pybind11::arg("downsample_images") = true)
+             pybind11::arg("downsample_images") = false)
         .def("get_sensor_info", &PylonDriver::get_sensor_info)
         .def("get_observation", &PylonDriver::get_observation);
 #endif

--- a/srcpy/py_tricamera_types.cpp
+++ b/srcpy/py_tricamera_types.cpp
@@ -34,7 +34,7 @@ PYBIND11_MODULE(py_tricamera_types, m)
              pybind11::arg("camera1"),
              pybind11::arg("camera2"),
              pybind11::arg("camera3"),
-             pybind11::arg("downsample_images") = true)
+             pybind11::arg("downsample_images") = false)
         .def(pybind11::init<const std::filesystem::path&,
                             const std::filesystem::path&,
                             const std::filesystem::path&,
@@ -42,7 +42,7 @@ PYBIND11_MODULE(py_tricamera_types, m)
              pybind11::arg("camera_calibration_file_1"),
              pybind11::arg("camera_calibration_file_2"),
              pybind11::arg("camera_calibration_file_3"),
-             pybind11::arg("downsample_images") = true)
+             pybind11::arg("downsample_images") = false)
         .def_readonly("rate", &TriCameraDriver::rate)
         .def("get_sensor_info", &TriCameraDriver::get_sensor_info)
         .def("get_observation", &TriCameraDriver::get_observation);


### PR DESCRIPTION

## Description
The downsampling and following un-demosaicing just degrade image quality and make it less flexible for the user.
Since the image size needs to be hard-coded for the multi-process time series, it is also not easy to make this runtime-configurable.  Therefore completely drop it from the driver.  Users can still downsample images on their side, if needed.

Note that this will increase memory requirements for the time series buffers by factor 4, though.  Hopefully that is not an issue given the amount of memory our robot computers have.  Likewise storage requirements for the recorded data increases.


## How I Tested

Ran an existing RL policy (which doesn't use the images directly) with this change.
