### PR TITLE
Add TriCameraLogger with option to save as HDF5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,10 @@
   viewing.
 - Add clipping indicator to `tricamera_log_viewer` (meant as an aid to find good
   exposure settings for the cameras).
+- `TriCameraLogger` which extends the generic `robot_interfaces::SensorLogger` by a
+  method `stop_and_save_hdf5`, which, as the name says, saves the data to an HDF5 file
+  instead of the built-in format.  It is recommended to use HDF5 when possible as it
+  is a standardized format that can be read without needing to depend on our code.
 
 ### Removed
 - Obsolete script `verify_calibration.py`

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -224,6 +224,20 @@ ament_target_dependencies(camera_calibration_parser
 list(APPEND install_targets camera_calibration_parser)
 
 
+add_library(tricamera_logger
+    src/tricamera_logger.cpp
+)
+target_include_directories(tricamera_logger PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>
+)
+target_link_libraries(tricamera_logger
+    robot_interfaces::robot_interfaces
+    ${OpenCV_LIBRARIES}
+)
+list(APPEND install_targets tricamera_logger)
+
+
 add_executable(load_camera_config_test src/load_camera_config_test.cpp)
 target_include_directories(load_camera_config_test PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
@@ -248,6 +262,7 @@ add_pybind11_module(py_tricamera_types srcpy/py_tricamera_types.cpp
         ${OpenCV_LIBRARIES}
         ${tricamera_driver}
         pybullet_tricamera_driver
+        tricamera_logger
 )
 
 

--- a/doc/breathing_cat.toml
+++ b/doc/breathing_cat.toml
@@ -5,3 +5,4 @@ auto_general_docs = false
 [intersphinx.mapping]
 trifinger_docs = "https://open-dynamic-robot-initiative.github.io/trifinger_docs"
 robot_fingers = "https://open-dynamic-robot-initiative.github.io/robot_fingers"
+robot_interfaces = "https://open-dynamic-robot-initiative.github.io/robot_interfaces"

--- a/doc/executables.rst
+++ b/doc/executables.rst
@@ -190,3 +190,23 @@ Images will be saved in the output directory using the following structure:
 
 
 See ``--help`` for available options.
+
+
+.. _executable_tricamera_log_to_hdf5:
+
+tricamera_log_to_hdf5
+=====================
+
+Convert a TriCamera log file from the primitive binary dump format (produced by
+:cpp:func:`robot_interfaces::SensorLogger::stop_and_save`) to HDF5.  See
+:doc:`hdf5_log_files` for more information on the HDF5 structure.
+
+Requires the camera calibration parameter files as the parameters are included in the
+HDF5 file but not in the primitive dump.
+
+Usage example:
+
+.. code-block::
+
+    tricamera_log_to_hdf5 -l camera_data.dat -c camera{60,180,300}_cropped.yml \
+        -o camera_data.hdf5

--- a/doc/hdf5_log_files.rst
+++ b/doc/hdf5_log_files.rst
@@ -1,0 +1,56 @@
+***************************
+TriCameraLogger HDF5 Format
+***************************
+
+The :cpp:class:`~trifinger_cameras::TriCameraLogger` provides a method
+:cpp:func:`~trifinger_cameras::TriCameraLogger::stop_and_save_hdf5`, which stores the
+logged data to an HDF5 file.
+
+Further, the script :ref:`executable_tricamera_log_to_hdf5` can be used to convert
+existing TriCamera logs from the legacy binary dump file (produced by :cpp:func:`robot_interfaces::SensorLogger::stop_and_save`) to HDF5.
+
+
+Root Attributes
+===============
+
+- ``magic``: Magic byte to easily identify the file as a TriCamera log.
+- ``format_version``: Major version of the file format (used for compatibility checks)
+- ``format_version_minor``: Minor version of the file format (used for compatibility checks)
+- ``num_cameras``: Number of cameras (should always be 3).
+- ``image_width``: Width of the recorded images.
+- ``image_height``: Height of the recorded images.
+
+
+Camera Parameters
+=================
+
+There are three groups ``/camera_info/camera60``, ``/camera_info/camera180`` and
+``/camera_info/camera300`` which contain the intrinsic and extrinsic parameters of the
+corresponding parameters.
+
+Each of these groups contains:
+
+- Attribute ``frame_rate_fps`` with the frame rate of the camera (should be the same for
+  all cameras but is recorded separately for consistency).
+- Datasets ``camera_matrix`` (3x3), ``distortion_coefficients`` (1x5) with intrinsic parameters.
+- Dataset ``tf_world_to_camera`` (4x4) with homogeneous transformation matrix from world
+  to camera frame.
+
+This corresponds to the data contained in
+:cpp:struct:``~trifinger_cameras::CameraInfo``.
+
+
+Camera Observations
+===================
+
+- Dataset ``/images``:  The actual images.  Dimensions are ``(n_observations, n_cameras,
+  image_height, image_width)``.  Individual images are single-channel and need to be
+  demosaiced before usage.
+- Dataset ``/timestamps``: Timestamps of the images, when they where acquired from the
+  cameras.  For each there are separate timestamps for the different cameras as they may
+  not be perfectly synchronised.  Corresponds to the timestamps included in :cpp:class:`~trifinger_cameras::TriCameraObservation`.  Shape ``(n_observations, n_cameras)``.
+- Dataset ``/sensor_data_timestamps``:  Timestamps of when the observation was added to
+  the sensor data (that is, when it was available to the user).  Corresponds to the
+  timestamp provided by :cpp:func:`robot_interfaces::SensorFrontend::get_timestamp_ms`.
+  Might be useful to replay the data with the same timing as it had when recording.
+

--- a/doc_mainpage.rst
+++ b/doc_mainpage.rst
@@ -10,6 +10,7 @@ The source code is hosted on GitHub_.
    doc/installation.rst
    doc/configuration.rst
    doc/pylon.rst
+   doc/hdf5_log_files.rst
    doc/troubleshooting.rst
 
 .. toctree::

--- a/include/trifinger_cameras/tricamera_logger.hpp
+++ b/include/trifinger_cameras/tricamera_logger.hpp
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <robot_interfaces/sensors/sensor_logger.hpp>
+
+#include <trifinger_cameras/camera_parameters.hpp>
+#include <trifinger_cameras/tricamera_observation.hpp>
+
+namespace trifinger_cameras
+{
+/**
+ * @brief Logger for TriCamera observations with option to save to HDF5 file.
+ *
+ * Extends the generic robot_interfaces::SensorLogger with a method @ref
+ * stop_and_save_hdf5, which saves the data to an HDF5 file instead of the
+ * native binary format.
+ */
+class TriCameraLogger
+    : public robot_interfaces::SensorLogger<TriCameraObservation, TriCameraInfo>
+{
+public:
+    using robot_interfaces::SensorLogger<TriCameraObservation,
+                                         TriCameraInfo>::SensorLogger;
+    /**
+     * @brief Stop logging and save logged messages to a HDF5 file.
+     *
+     * @param filename Path to the output file.  Existing files will be
+     *     overwritten.
+     */
+    void stop_and_save_hdf5(const std::string &filename);
+};
+}  // namespace trifinger_cameras

--- a/scripts/record_tricamera_log.py
+++ b/scripts/record_tricamera_log.py
@@ -63,7 +63,7 @@ def main() -> int:
 
     log_size = int(camera_info.camera[0].frame_rate_fps * args.buffer_size)
 
-    camera_logger = trifinger_cameras.tricamera.Logger(camera_data, log_size)
+    camera_logger = trifinger_cameras.tricamera.TriCameraLogger(camera_data, log_size)
     camera_logger.start()
     logging.info("Start camera logging.  Press Ctrl+C to stop and save.")
 
@@ -71,8 +71,12 @@ def main() -> int:
     while not signal_handler.has_received_sigint():
         time.sleep(1)
 
-    logging.info("Save recorded camera data to file %s", args.output_path)
-    camera_logger.stop_and_save(str(args.output_path))
+    if args.output_path.suffix in (".hdf5", ".h5"):
+        logging.info("Save recorded camera data to HDF5 file %s", args.output_path)
+        camera_logger.stop_and_save_hdf5(str(args.output_path))
+    else:
+        logging.info("Save recorded camera data to file %s", args.output_path)
+        camera_logger.stop_and_save(str(args.output_path))
 
     camera_backend.shutdown()
 

--- a/scripts/tricamera_log_to_hdf5.py
+++ b/scripts/tricamera_log_to_hdf5.py
@@ -91,6 +91,7 @@ def main() -> int:
         h5.create_dataset("camera_names", data=[name.encode() for name in CAMERA_NAMES])
         h5.attrs["magic"] = TRICAMERA_LOG_MAGIC
         h5.attrs["format_version"] = 2
+        h5.attrs["format_version_minor"] = 1
         h5.attrs["num_cameras"] = len(CAMERA_NAMES)
         h5.attrs["image_width"] = img_shape[1]
         h5.attrs["image_height"] = img_shape[0]
@@ -119,17 +120,27 @@ def main() -> int:
             shuffle=True,
         )
 
-        # TODO: need to distinguish between camera timestamps and time series timestamps
+        # timestamps from the camera observations
         h5.create_dataset(
             "timestamps",
             shape=(n_frames, len(CAMERA_NAMES)),
             dtype=np.double,
         )
 
-        for i_obs, observation in enumerate(log_reader.data):
+        # timestamps from the sensor data time series
+        h5.create_dataset(
+            "sensor_data_timestamps",
+            shape=(n_frames,),
+            dtype=np.double,
+        )
+
+        for i_obs, (observation, data_timestamp) in enumerate(
+            zip(log_reader.data, log_reader.timestamps)
+        ):
             cameras = observation.cameras
             h5["images"][i_obs] = [camera.image for camera in cameras]
             h5["timestamps"][i_obs] = [camera.timestamp for camera in cameras]
+            h5["sensor_data_timestamps"][i_obs] = data_timestamp
 
     return 0
 

--- a/scripts/tricamera_log_to_hdf5.py
+++ b/scripts/tricamera_log_to_hdf5.py
@@ -119,6 +119,7 @@ def main() -> int:
             shuffle=True,
         )
 
+        # TODO: need to distinguish between camera timestamps and time series timestamps
         h5.create_dataset(
             "timestamps",
             shape=(n_frames, len(CAMERA_NAMES)),

--- a/src/tricamera_logger.cpp
+++ b/src/tricamera_logger.cpp
@@ -23,15 +23,21 @@ void TriCameraLogger::stop_and_save_hdf5(const std::string &filename)
     cv::Ptr<cv::hdf::HDF5> h5io = cv::hdf::open(filename);
 
     constexpr int TRICAMERA_LOG_MAGIC = 0x3CDA7A00;
-    constexpr int FORMAT_VERSION = 2;
+    constexpr int FORMAT_VERSION_MAJOR = 2;
+    constexpr int FORMAT_VERSION_MINOR = 1;
     constexpr int NUM_CAMERAS = 3;
+
+    const std::string DS_IMAGES = "images";
+    const std::string DS_CAMERA_TIMESTAMPS = "timestamps";
+    const std::string DS_TIMESERIES_TIMESTAMPS = "sensor_data_timestamps";
 
     // check if buffer is empty
     int image_width = std::get<1>(buffer_[0]).cameras[0].image.cols;
     int image_height = std::get<1>(buffer_[0]).cameras[0].image.rows;
 
     h5io->atwrite(TRICAMERA_LOG_MAGIC, "magic");
-    h5io->atwrite(FORMAT_VERSION, "format_version");
+    h5io->atwrite(FORMAT_VERSION_MAJOR, "format_version");
+    h5io->atwrite(FORMAT_VERSION_MINOR, "format_version_minor");
     h5io->atwrite(NUM_CAMERAS, "num_cameras");
     h5io->atwrite(image_width, "image_width");
     h5io->atwrite(image_height, "image_height");
@@ -73,12 +79,16 @@ void TriCameraLogger::stop_and_save_hdf5(const std::string &filename)
         n_frames, NUM_CAMERAS, image_height, image_width};
     std::vector<int> images_chunks{1, NUM_CAMERAS, image_height, image_width};
     h5io->dscreate(
-        images_size, CV_8UC1, "images", compression_level, images_chunks);
+        images_size, CV_8UC1, DS_IMAGES, compression_level, images_chunks);
 
-    // FIXME: need to distinguish between camera timestamps and time series
-    // stamps
+    // timestamps from the camera observations (when images were captured)
     h5io->dscreate(
-        std::vector<int>{n_frames, NUM_CAMERAS}, CV_64F, "timestamps");
+        std::vector<int>{n_frames, NUM_CAMERAS}, CV_64F, DS_CAMERA_TIMESTAMPS);
+
+    // timestamps from the time series (when observations were added to the
+    // sensor data and thus available to the user)
+    h5io->dscreate(
+        std::vector<int>{n_frames}, CV_64F, DS_TIMESERIES_TIMESTAMPS);
 
     // Write the observations to the HDF5 file
     for (int i_obs = 0; i_obs < n_frames; ++i_obs)
@@ -92,7 +102,9 @@ void TriCameraLogger::stop_and_save_hdf5(const std::string &filename)
         cv::Mat images(
             std::vector<int>{1, NUM_CAMERAS, image_height, image_width},
             CV_8UC1);
-        cv::Mat timestamps(1, NUM_CAMERAS, CV_64F);
+        cv::Mat camera_timestamps(1, NUM_CAMERAS, CV_64F);
+
+        double timeseries_timestamp = std::get<0>(buffer_[i_obs]);
 
         for (int i_cam = 0; i_cam < NUM_CAMERAS; ++i_cam)
         {
@@ -111,11 +123,20 @@ void TriCameraLogger::stop_and_save_hdf5(const std::string &filename)
 
             camera.image.copyTo(images_slice);
 
-            timestamps.at<double>(0, i_cam) = camera.timestamp;
+            camera_timestamps.at<double>(0, i_cam) = camera.timestamp;
         }
 
-        h5io->dswrite(images, "images", std::vector<int>{i_obs, 0, 0, 0});
-        h5io->dswrite(timestamps, "timestamps", std::vector<int>{i_obs, 0});
+        h5io->dswrite(images, DS_IMAGES, std::vector<int>{i_obs, 0, 0, 0});
+        h5io->dswrite(camera_timestamps,
+                      DS_CAMERA_TIMESTAMPS,
+                      std::vector<int>{i_obs, 0});
+
+        // OpenCV's HDF5 interface can only write Mat to datasets, so even
+        // scalar values need to be wrapped in a Mat.
+        cv::Mat timeseries_timestamp_mat(1, 1, CV_64F, timeseries_timestamp);
+        h5io->dswrite(timeseries_timestamp_mat,
+                      DS_TIMESERIES_TIMESTAMPS,
+                      std::vector<int>{i_obs});
     }
 
     h5io->close();

--- a/src/tricamera_logger.cpp
+++ b/src/tricamera_logger.cpp
@@ -1,0 +1,123 @@
+#include <trifinger_cameras/tricamera_logger.hpp>
+
+#include <filesystem>
+
+#include <opencv2/core/eigen.hpp>
+#include <opencv2/hdf/hdf5.hpp>
+
+namespace trifinger_cameras
+{
+void TriCameraLogger::stop_and_save_hdf5(const std::string &filename)
+{
+    stop();
+
+    if (buffer_.empty())
+    {
+        throw std::runtime_error("Buffer is empty, nothing to save.");
+    }
+
+    // existing files shall be overwritten, so if it already exists, delete the
+    // old one
+    std::filesystem::remove(filename);
+
+    cv::Ptr<cv::hdf::HDF5> h5io = cv::hdf::open(filename);
+
+    constexpr int TRICAMERA_LOG_MAGIC = 0x3CDA7A00;
+    constexpr int FORMAT_VERSION = 2;
+    constexpr int NUM_CAMERAS = 3;
+
+    // check if buffer is empty
+    int image_width = std::get<1>(buffer_[0]).cameras[0].image.cols;
+    int image_height = std::get<1>(buffer_[0]).cameras[0].image.rows;
+
+    h5io->atwrite(TRICAMERA_LOG_MAGIC, "magic");
+    h5io->atwrite(FORMAT_VERSION, "format_version");
+    h5io->atwrite(NUM_CAMERAS, "num_cameras");
+    h5io->atwrite(image_width, "image_width");
+    h5io->atwrite(image_height, "image_height");
+
+    // Add camera calibration parameters
+    h5io->grcreate("/camera_info");
+    TriCameraInfo info = sensor_data_->sensor_info->newest_element();
+
+    const std::array<std::string, 3> CAMERA_NAMES = {
+        "camera60", "camera180", "camera300"};
+    for (size_t i = 0; i < NUM_CAMERAS; ++i)
+    {
+        const CameraInfo &params = info.camera[i];
+        std::string group_name = "/camera_info/" + CAMERA_NAMES[i];
+        h5io->grcreate(group_name);
+
+        h5io->atwrite(params.frame_rate_fps, group_name + "/frame_rate_fps");
+
+        // datasets are auto-created when writing, so as long as no special
+        // settings like compression are needed, we can skip dscreate() here.
+
+        cv::Mat camera_matrix;
+        cv::eigen2cv(params.camera_matrix, camera_matrix);
+        h5io->dswrite(camera_matrix, group_name + "/camera_matrix");
+
+        cv::Mat distortion_coeffs;
+        cv::eigen2cv(params.distortion_coefficients, distortion_coeffs);
+        h5io->dswrite(distortion_coeffs,
+                      group_name + "/distortion_coefficients");
+
+        cv::Mat tf_world_to_camera;
+        cv::eigen2cv(params.tf_world_to_camera, tf_world_to_camera);
+        h5io->dswrite(tf_world_to_camera, group_name + "/tf_world_to_camera");
+    }
+
+    const int n_frames = static_cast<int>(buffer_.size());
+    constexpr int compression_level = 4;
+    std::vector<int> images_size{
+        n_frames, NUM_CAMERAS, image_height, image_width};
+    std::vector<int> images_chunks{1, NUM_CAMERAS, image_height, image_width};
+    h5io->dscreate(
+        images_size, CV_8UC1, "images", compression_level, images_chunks);
+
+    // FIXME: need to distinguish between camera timestamps and time series
+    // stamps
+    h5io->dscreate(
+        std::vector<int>{n_frames, NUM_CAMERAS}, CV_64F, "timestamps");
+
+    // Write the observations to the HDF5 file
+    for (int i_obs = 0; i_obs < n_frames; ++i_obs)
+    {
+        // Collect the images of all cameras into one multi-dimensional mat, so
+        // we can write the whole chunk at once to the HDF5 dataset (is supposed
+        // to be more efficient than writing parts of the chunk separately). We
+        // add a useless dimension of size 1 at the beginning, so `images`
+        // already matches the dimensions of the dataset (makes it easier to
+        // write to the dataset later on).
+        cv::Mat images(
+            std::vector<int>{1, NUM_CAMERAS, image_height, image_width},
+            CV_8UC1);
+        cv::Mat timestamps(1, NUM_CAMERAS, CV_64F);
+
+        for (int i_cam = 0; i_cam < NUM_CAMERAS; ++i_cam)
+        {
+            const CameraObservation &camera =
+                std::get<1>(buffer_[i_obs]).cameras[i_cam];
+
+            // Get slice of `images` to which we can write the single image.
+            // The reshape is needed to flatten out the dimensions for n_frames
+            // and n_cameras (which are of size 1 in the slice).
+            std::vector<cv::Range> img_range{cv::Range::all(),
+                                             cv::Range(i_cam, i_cam + 1),
+                                             cv::Range::all(),
+                                             cv::Range::all()};
+            cv::Mat images_slice = images(img_range).reshape(
+                0, std::vector<int>{image_height, image_width});
+
+            camera.image.copyTo(images_slice);
+
+            timestamps.at<double>(0, i_cam) = camera.timestamp;
+        }
+
+        h5io->dswrite(images, "images", std::vector<int>{i_obs, 0, 0, 0});
+        h5io->dswrite(timestamps, "timestamps", std::vector<int>{i_obs, 0});
+    }
+
+    h5io->close();
+}
+}  // namespace trifinger_cameras

--- a/srcpy/py_tricamera_types.cpp
+++ b/srcpy/py_tricamera_types.cpp
@@ -7,6 +7,7 @@
 #include <pybind11/stl/filesystem.h>
 
 #include <trifinger_cameras/pybullet_tricamera_driver.hpp>
+#include <trifinger_cameras/tricamera_logger.hpp>
 #include <trifinger_cameras/tricamera_observation.hpp>
 #ifdef Pylon_FOUND
 #include <trifinger_cameras/tricamera_driver.hpp>
@@ -72,4 +73,11 @@ PYBIND11_MODULE(py_tricamera_types, m)
              pybind11::arg("render_images") = true)
         .def("get_sensor_info", &PyBulletTriCameraDriver::get_sensor_info)
         .def("get_observation", &PyBulletTriCameraDriver::get_observation);
+
+    pybind11::class_<TriCameraLogger,
+                     std::shared_ptr<TriCameraLogger>,
+                     SensorLogger<TriCameraObservation, TriCameraInfo>>(
+        m, "TriCameraLogger")
+        .def(pybind11::init<typename TriCameraLogger::DataPtr, size_t>())
+        .def("stop_and_save_hdf5", &TriCameraLogger::stop_and_save_hdf5);
 }


### PR DESCRIPTION
## Description

Add class `TriCameraLogger` that inherits from `robot_interfaces::SensorLogger` and extends it by a method `stop_and_save_hdf5`, that uses HDF5 as output format.


## How I Tested

Used it to record some data.